### PR TITLE
Upgrade for higher versions of Laravel and PHP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /.idea
+/vendor/
+/composer.lock

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,17 @@
     },
     "minimum-stability": "dev",
     "require": {
-        "davispeixoto/laravel5-salesforce": "~2.0"
+        "laravel/framework": "^9.0|^10.0|^11.0",
+        "ext-soap": "*"
+    },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "CEE\\Salesforce\\Laravel\\SalesforceServiceProvider"
+            ],
+            "aliases": {
+                "Salesforce": "CEE\\Salesforce\\Laravel\\Facades\\Salesforce"
+            }
+        }
     }
 }

--- a/license.md
+++ b/license.md
@@ -2,6 +2,10 @@ The MIT License (MIT)
 
 Copyright (c) 2019 John Wilson
 
+[Copyright (c) 2010, Salesforce.com](src/ForceDotCom/LICENSE.md)
+
+[Copyright (c) 2015 Davis Peixoto](src/Laravel/LICENSE.md)
+
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.

--- a/readme.md
+++ b/readme.md
@@ -1,41 +1,30 @@
 # Salesforce Sync
 
-This package is for syncing Salesforce objects with local data. It's an extension of Davis Peixoto's [Laravel 5 Salesforce](https://github.com/davispeixoto/Laravel-5-Salesforce) package.
+This package is for syncing Salesforce objects with local data in a Laravel app.
 
-Works with [Laravel 5.2](https://laravel.com/docs/) and up.
+Works with [Laravel 9, 10, and 11](https://laravel.com/docs/11.x).
+
+[*Use version `^1.0` for Laravel 5*](https://github.com/jwilson-cee/salesforce-sync/tree/v1.0.9)
 
 ## Installation
 
-This package can be installed via [Composer](http://getcomposer.org) by requiring the
-`mncee/salesforce-sync` package in your project's `composer.json`.
+This package can be installed via [Composer](http://getcomposer.org) by requiring the `mncee/salesforce-sync` package.
 
-```json
-{
-    "require": {
-        "mncee/salesforce-sync": "1.0.*"
-    }
-}
+```shell
+composer require mncee/salesforce-sync
 ```
 
-### Laravel 5 Configuration
+[*For Laravel 5*](https://github.com/jwilson-cee/salesforce-sync/tree/v1.0.9)
 
-To use the [Laravel 5 Salesforce](https://github.com/davispeixoto/Laravel-5-Salesforce) package, you must add the service provider and facade alias your Laravel 5 application.
-
-Find the `providers` key and `aliases` key in your `config/app.php` and add these corresponding lines.
-
-```php
-    'providers' => array(
-        // ...
-        Davispeixoto\Laravel5Salesforce\SalesforceServiceProvider::class,
-    )
-    
-    'aliases' => array(
-        // ...
-        'Salesforce' => Davispeixoto\Laravel5Salesforce\SalesforceFacade::class,
-    )
+```shell
+composer require mncee/salesforce-sync:^1.0
 ```
 
-Then you must include the following environment variables in the `.env` file:
+## Laravel Configuration
+
+### Environment Variables
+
+Include the following environment variables in the `.env` file:
 ```
 SALESFORCE_USERNAME=#your salesfore username#
 SALESFORCE_PASSWORD=#your salesfore password#
@@ -45,7 +34,65 @@ SALESFORCE_WSDL=#path to the wsdl stored in the storage/app/ directory#
 
 Place your [your **Enterprise** WSDL file](https://developer.salesforce.com/docs/atlas.en-us.api.meta/api/sforce_api_quickstart_steps_generate_wsdl.htm) into your app `storage/app/` directory you specified in the `.env` file.
 
-**IMPORTANT:** the PHP Force.com Toolkit for PHP only works with Enterprise WSDL
+**IMPORTANT:** This package only works with Enterprise WSDL
+
+### Package Discovery
+
+This packages *Service Provider* and *Facade alias* should be auto-discovered when requiring it with `composer`.
+
+But if you need to add them manually, you can do so with the following instructions:
+
+#### For Laravel 11
+
+In the `bootstrap/providers.php` file add `CEE\Salesforce\Laravel\SalesforceServiceProvider::class` to the returned array.
+
+```php
+// bootstrap/providers.php
+
+return [
+    App\Providers\AppServiceProvider::class,
+    CEE\Salesforce\Laravel\SalesforceServiceProvider::class,
+];
+```
+
+In the `config/app.php` file add these corresponding lines to the returned array.
+
+```php
+// config/app.php
+
+return [
+    
+    //...
+    
+    'aliases' => Facade::defaultAliases()->merge([
+        'Salesforce' => \CEE\Salesforce\Laravel\Facades\Salesforce::class,
+    ])->toArray(),
+]
+```
+
+#### For Laravel 9 and 10
+
+Find the `providers` key and `aliases` key in your `config/app.php` and add these corresponding lines to the returned array.
+
+```php
+// config/app.php
+
+return [
+    
+    //...
+    
+    'providers' => [
+        // ...
+        CEE\Salesforce\Laravel\SalesforceServiceProvider::class,
+    ],
+    
+    'aliases' => [
+        // ...
+        'Salesforce' => \CEE\Salesforce\Laravel\Facades\Salesforce::class,
+    ],
+    
+];
+```
 
 ## The SyncObject Class
 This is the class to use for syncing local data with remote Salesforce objects.

--- a/src/ForceDotCom/AllowFieldTruncationHeader.php
+++ b/src/ForceDotCom/AllowFieldTruncationHeader.php
@@ -1,0 +1,39 @@
+<?php namespace CEE\Salesforce\ForceDotCom;
+
+/*
+ * Copyright (c) 2007, salesforce.com, inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided
+ * that the following conditions are met:
+ *
+ *    Redistributions of source code must retain the above copyright notice, this list of conditions and the
+ *    following disclaimer.
+ *
+ *    Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *    the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ *    Neither the name of salesforce.com, inc. nor the names of its contributors may be used to endorse or
+ *    promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+class AllowFieldTruncationHeader
+{
+    public $allowFieldTruncation;
+
+    public function __construct($allowFieldTruncation)
+    {
+        $this->allowFieldTruncation = $allowFieldTruncation;
+    }
+}
+
+?>

--- a/src/ForceDotCom/AssignmentRuleHeader.php
+++ b/src/ForceDotCom/AssignmentRuleHeader.php
@@ -1,0 +1,60 @@
+<?php namespace CEE\Salesforce\ForceDotCom;
+
+    /*
+     * Copyright (c) 2007, salesforce.com, inc.
+     * All rights reserved.
+     *
+     * Redistribution and use in source and binary forms, with or without modification, are permitted provided
+     * that the following conditions are met:
+     *
+     *    Redistributions of source code must retain the above copyright notice, this list of conditions and the
+     *    following disclaimer.
+     *
+     *    Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+     *    the following disclaimer in the documentation and/or other materials provided with the distribution.
+     *
+     *    Neither the name of salesforce.com, inc. nor the names of its contributors may be used to endorse or
+     *    promote products derived from this software without specific prior written permission.
+     *
+     * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+     * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+     * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+     * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+     * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+     * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+     * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+     * POSSIBILITY OF SUCH DAMAGE.
+     */
+
+/**
+ * To be used with Create and Update operations.
+ * Only one attribute can be set at a time.
+ *
+ * @package SalesforceSoapClient
+ */
+class AssignmentRuleHeader
+{
+    // int
+    public $assignmentRuleId;
+    // boolean
+    public $useDefaultRuleFlag;
+
+    /**
+     * Constructor.  Only one param can be set.
+     *
+     * @param int $id AssignmentRuleId
+     * @param boolean $flag UseDefaultRule flag
+     */
+    public function __construct($id = null, $flag = null)
+    {
+        if ($id != null) {
+            $this->assignmentRuleId = $id;
+        }
+
+        if ($flag != null) {
+            $this->useDefaultRuleFlag = $flag;
+        }
+    }
+}
+
+?>

--- a/src/ForceDotCom/CallOptions.php
+++ b/src/ForceDotCom/CallOptions.php
@@ -1,0 +1,41 @@
+<?php namespace CEE\Salesforce\ForceDotCom;
+
+/*
+ * Copyright (c) 2007, salesforce.com, inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided
+ * that the following conditions are met:
+ *
+ *    Redistributions of source code must retain the above copyright notice, this list of conditions and the
+ *    following disclaimer.
+ *
+ *    Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *    the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ *    Neither the name of salesforce.com, inc. nor the names of its contributors may be used to endorse or
+ *    promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+class CallOptions
+{
+    public $client;
+    public $defaultNamespace;
+
+    public function __construct($client, $defaultNamespace = null)
+    {
+        $this->client = $client;
+        $this->defaultNamespace = $defaultNamespace;
+    }
+}
+
+?>

--- a/src/ForceDotCom/Email.php
+++ b/src/ForceDotCom/Email.php
@@ -1,0 +1,73 @@
+<?php namespace CEE\Salesforce\ForceDotCom;
+
+/*
+ * Copyright (c) 2007, salesforce.com, inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided
+ * that the following conditions are met:
+ *
+ *    Redistributions of source code must retain the above copyright notice, this list of conditions and the
+ *    following disclaimer.
+ *
+ *    Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *    the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ *    Neither the name of salesforce.com, inc. nor the names of its contributors may be used to endorse or
+ *    promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+class Email
+{
+    const EMAIL_PRIORITY_HIGHEST = 'Highest';
+    const EMAIL_PRIORITY_HIGH = 'High';
+    const EMAIL_PRIORITY_NORMAL = 'Normal';
+    const EMAIL_PRIORITY_LOW = 'Low';
+    const EMAIL_PRIORITY_LOWEST = 'Lowest';
+
+    public function setBccSender($bccSender)
+    {
+        $this->bccSender = $bccSender;
+    }
+
+    public function setEmailPriority($priority)
+    {
+        $this->emailPriority = $priority;
+    }
+
+    public function setSubject($subject)
+    {
+        $this->subject = $subject;
+    }
+
+    public function setSaveAsActivity($saveAsActivity)
+    {
+        $this->saveAsActivity = $saveAsActivity;
+    }
+
+    public function setReplyTo($replyTo)
+    {
+        $this->replyTo = $replyTo;
+    }
+
+    public function setUseSignature($useSignature)
+    {
+        $this->useSignature = $useSignature;
+    }
+
+    public function setSenderDisplayName($name)
+    {
+        $this->senderDisplayName = $name;
+    }
+}
+
+?>

--- a/src/ForceDotCom/EmailHeader.php
+++ b/src/ForceDotCom/EmailHeader.php
@@ -1,0 +1,46 @@
+<?php namespace CEE\Salesforce\ForceDotCom;
+
+/*
+ * Copyright (c) 2007, salesforce.com, inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided
+ * that the following conditions are met:
+ *
+ *    Redistributions of source code must retain the above copyright notice, this list of conditions and the
+ *    following disclaimer.
+ *
+ *    Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *    the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ *    Neither the name of salesforce.com, inc. nor the names of its contributors may be used to endorse or
+ *    promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+class EmailHeader
+{
+    public $triggerAutoResponseEmail;
+    public $triggerOtherEmail;
+    public $triggerUserEmail;
+
+    public function __construct(
+        $triggerAutoResponseEmail = false,
+        $triggerOtherEmail = false,
+        $triggerUserEmail = false
+    ) {
+        $this->triggerAutoResponseEmail = $triggerAutoResponseEmail;
+        $this->triggerOtherEmail = $triggerOtherEmail;
+        $this->triggerUserEmail = $triggerUserEmail;
+    }
+}
+
+?>

--- a/src/ForceDotCom/LICENSE.md
+++ b/src/ForceDotCom/LICENSE.md
@@ -1,0 +1,32 @@
+This project is licensed under the 'BSD 3-Clause' license [1], also known as 
+the 'Modified BSD' license [2].
+
+[1] http://www.opensource.org/licenses/BSD-3-Clause
+
+[2] http://www.gnu.org/licenses/license-list.html#ModifiedBSD
+
+Copyright (c) 2010, Salesforce.com
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without 
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this 
+  list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright notice, 
+  this list of conditions and the following disclaimer in the documentation 
+  and/or other materials provided with the distribution.
+* Neither the name of Salesforce.com nor the names of its contributors may be 
+  used to endorse or promote products derived from this software without 
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE 
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, 
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/src/ForceDotCom/LocaleOptions.php
+++ b/src/ForceDotCom/LocaleOptions.php
@@ -1,0 +1,46 @@
+<?php namespace CEE\Salesforce\ForceDotCom;
+
+/*
+ * Copyright (c) 2007, salesforce.com, inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided
+ * that the following conditions are met:
+ *
+ *    Redistributions of source code must retain the above copyright notice, this list of conditions and the
+ *    following disclaimer.
+ *
+ *    Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *    the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ *    Neither the name of salesforce.com, inc. nor the names of its contributors may be used to endorse or
+ *    promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+class LocaleOptions
+{
+    public $language;
+
+    /**
+     * Class constructor.
+     *
+     * @param string $language
+     * @return void
+     */
+    public function __construct($language)
+    {
+        $this->language = $language;
+    }
+}
+
+?>

--- a/src/ForceDotCom/LoginScopeHeader.php
+++ b/src/ForceDotCom/LoginScopeHeader.php
@@ -1,0 +1,47 @@
+<?php namespace CEE\Salesforce\ForceDotCom;
+
+    /*
+     * Copyright (c) 2007, salesforce.com, inc.
+     * All rights reserved.
+     *
+     * Redistribution and use in source and binary forms, with or without modification, are permitted provided
+     * that the following conditions are met:
+     *
+     *    Redistributions of source code must retain the above copyright notice, this list of conditions and the
+     *    following disclaimer.
+     *
+     *    Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+     *    the following disclaimer in the documentation and/or other materials provided with the distribution.
+     *
+     *    Neither the name of salesforce.com, inc. nor the names of its contributors may be used to endorse or
+     *    promote products derived from this software without specific prior written permission.
+     *
+     * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+     * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+     * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+     * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+     * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+     * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+     * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+     * POSSIBILITY OF SUCH DAMAGE.
+     */
+
+/**
+ * To be used with the Login operation.
+ *
+ * @package SalesforceSoapClient
+ */
+class LoginScopeHeader
+{
+    // boolean that Indicates whether to update the list of most recently used items (True) or not (False).
+    public $organizationId;
+    public $portalId;
+
+    public function __construct($orgId = null, $portalId = null)
+    {
+        $this->organizationId = $orgId;
+        $this->portalId = $portalId;
+    }
+}
+
+?>

--- a/src/ForceDotCom/MassEmailMessage.php
+++ b/src/ForceDotCom/MassEmailMessage.php
@@ -1,0 +1,46 @@
+<?php namespace CEE\Salesforce\ForceDotCom;
+
+/*
+ * Copyright (c) 2007, salesforce.com, inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided
+ * that the following conditions are met:
+ *
+ *    Redistributions of source code must retain the above copyright notice, this list of conditions and the
+ *    following disclaimer.
+ *
+ *    Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *    the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ *    Neither the name of salesforce.com, inc. nor the names of its contributors may be used to endorse or
+ *    promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+class MassEmailMessage extends Email
+{
+    public function setTemplateId($templateId)
+    {
+        $this->templateId = $templateId;
+    }
+
+    public function setWhatIds($array)
+    {
+        $this->whatIds = $array;
+    }
+
+    public function setTargetObjectIds($array)
+    {
+        $this->targetObjectIds = $array;
+    }
+}
+
+?>

--- a/src/ForceDotCom/MruHeader.php
+++ b/src/ForceDotCom/MruHeader.php
@@ -1,0 +1,45 @@
+<?php namespace CEE\Salesforce\ForceDotCom;
+
+    /*
+     * Copyright (c) 2007, salesforce.com, inc.
+     * All rights reserved.
+     *
+     * Redistribution and use in source and binary forms, with or without modification, are permitted provided
+     * that the following conditions are met:
+     *
+     *    Redistributions of source code must retain the above copyright notice, this list of conditions and the
+     *    following disclaimer.
+     *
+     *    Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+     *    the following disclaimer in the documentation and/or other materials provided with the distribution.
+     *
+     *    Neither the name of salesforce.com, inc. nor the names of its contributors may be used to endorse or
+     *    promote products derived from this software without specific prior written permission.
+     *
+     * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+     * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+     * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+     * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+     * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+     * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+     * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+     * POSSIBILITY OF SUCH DAMAGE.
+     */
+
+/**
+ * To be used with Create and Update operations.
+ *
+ * @package SalesforceSoapClient
+ */
+class MruHeader
+{
+    // boolean that Indicates whether to update the list of most recently used items (True) or not (False).
+    public $updateMruFlag;
+
+    public function __construct($bool)
+    {
+        $this->updateMruFlag = $bool;
+    }
+}
+
+?>

--- a/src/ForceDotCom/PackageVersion.php
+++ b/src/ForceDotCom/PackageVersion.php
@@ -1,0 +1,55 @@
+<?php namespace CEE\Salesforce\ForceDotCom;
+
+    /*
+     * Copyright (c) 2007, salesforce.com, inc.
+     * All rights reserved.
+     *
+     * Redistribution and use in source and binary forms, with or without modification, are permitted provided
+     * that the following conditions are met:
+     *
+     *    Redistributions of source code must retain the above copyright notice, this list of conditions and the
+     *    following disclaimer.
+     *
+     *    Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+     *    the following disclaimer in the documentation and/or other materials provided with the distribution.
+     *
+     *    Neither the name of salesforce.com, inc. nor the names of its contributors may be used to endorse or
+     *    promote products derived from this software without specific prior written permission.
+     *
+     * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+     * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+     * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+     * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+     * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+     * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+     * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+     * POSSIBILITY OF SUCH DAMAGE.
+     */
+
+/**
+ * This class is used by PackageVersionHeader
+ * @see PackageVersionHeader
+ */
+class PackageVersion
+{
+    public $majorNumber;
+    public $minorNumber;
+    public $namespace;
+
+    /**
+     * Class constructor.
+     *
+     * @param int $majorNumber
+     * @param int $minorNumber
+     * @param string $namespace
+     * @return void
+     */
+    public function __construct($majorNumber, $minorNumber, $namespace)
+    {
+        $this->majorNumber = $majorNumber;
+        $this->minorNumber = $minorNumber;
+        $this->namespace = $namespace;
+    }
+}
+
+?>

--- a/src/ForceDotCom/PackageVersionHeader.php
+++ b/src/ForceDotCom/PackageVersionHeader.php
@@ -1,0 +1,49 @@
+<?php namespace CEE\Salesforce\ForceDotCom;
+
+/*
+ * Copyright (c) 2007, salesforce.com, inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided
+ * that the following conditions are met:
+ *
+ *    Redistributions of source code must retain the above copyright notice, this list of conditions and the
+ *    following disclaimer.
+ *
+ *    Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *    the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ *    Neither the name of salesforce.com, inc. nor the names of its contributors may be used to endorse or
+ *    promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+class PackageVersionHeader
+{
+    /**
+     * @var array $packageVersions
+     */
+    public $packageVersions;
+
+    /**
+     * Class constructor.
+     *
+     * @param array $packageVersions
+     * @return void
+     */
+    public function __construct($packageVersions)
+    {
+        $this->packageVersions = $packageVersions;
+    }
+}
+
+
+?>

--- a/src/ForceDotCom/ProcessRequest.php
+++ b/src/ForceDotCom/ProcessRequest.php
@@ -1,0 +1,35 @@
+<?php namespace CEE\Salesforce\ForceDotCom;
+
+/*
+ * Copyright (c) 2007, salesforce.com, inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided
+ * that the following conditions are met:
+ *
+ *    Redistributions of source code must retain the above copyright notice, this list of conditions and the
+ *    following disclaimer.
+ *
+ *    Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *    the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ *    Neither the name of salesforce.com, inc. nor the names of its contributors may be used to endorse or
+ *    promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+abstract class ProcessRequest
+{
+    public $comments;
+    public $nextApproverIds;
+}
+
+?>

--- a/src/ForceDotCom/ProcessSubmitRequest.php
+++ b/src/ForceDotCom/ProcessSubmitRequest.php
@@ -1,0 +1,34 @@
+<?php namespace CEE\Salesforce\ForceDotCom;
+
+/*
+ * Copyright (c) 2007, salesforce.com, inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided
+ * that the following conditions are met:
+ *
+ *    Redistributions of source code must retain the above copyright notice, this list of conditions and the
+ *    following disclaimer.
+ *
+ *    Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *    the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ *    Neither the name of salesforce.com, inc. nor the names of its contributors may be used to endorse or
+ *    promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+class ProcessSubmitRequest extends ProcessRequest
+{
+    public $objectId;
+}
+
+?>

--- a/src/ForceDotCom/ProcessWorkitemRequest.php
+++ b/src/ForceDotCom/ProcessWorkitemRequest.php
@@ -1,0 +1,35 @@
+<?php namespace CEE\Salesforce\ForceDotCom;
+
+/*
+ * Copyright (c) 2007, salesforce.com, inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided
+ * that the following conditions are met:
+ *
+ *    Redistributions of source code must retain the above copyright notice, this list of conditions and the
+ *    following disclaimer.
+ *
+ *    Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *    the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ *    Neither the name of salesforce.com, inc. nor the names of its contributors may be used to endorse or
+ *    promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+class ProcessWorkitemRequest extends ProcessRequest
+{
+    public $action;
+    public $workitemId;
+}
+
+?>

--- a/src/ForceDotCom/ProxySettings.php
+++ b/src/ForceDotCom/ProxySettings.php
@@ -1,0 +1,36 @@
+<?php namespace CEE\Salesforce\ForceDotCom;
+
+/*
+ * Copyright (c) 2007, salesforce.com, inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided
+ * that the following conditions are met:
+ *
+ *    Redistributions of source code must retain the above copyright notice, this list of conditions and the
+ *    following disclaimer.
+ *
+ *    Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *    the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ *    Neither the name of salesforce.com, inc. nor the names of its contributors may be used to endorse or
+ *    promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+class ProxySettings
+{
+    public $host;
+    public $port;
+    public $login;
+    public $password;
+}
+
+?>

--- a/src/ForceDotCom/QueryOptions.php
+++ b/src/ForceDotCom/QueryOptions.php
@@ -1,0 +1,50 @@
+<?php namespace CEE\Salesforce\ForceDotCom;
+
+    /*
+     * Copyright (c) 2007, salesforce.com, inc.
+     * All rights reserved.
+     *
+     * Redistribution and use in source and binary forms, with or without modification, are permitted provided
+     * that the following conditions are met:
+     *
+     *    Redistributions of source code must retain the above copyright notice, this list of conditions and the
+     *    following disclaimer.
+     *
+     *    Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+     *    the following disclaimer in the documentation and/or other materials provided with the distribution.
+     *
+     *    Neither the name of salesforce.com, inc. nor the names of its contributors may be used to endorse or
+     *    promote products derived from this software without specific prior written permission.
+     *
+     * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+     * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+     * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+     * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+     * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+     * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+     * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+     * POSSIBILITY OF SUCH DAMAGE.
+     */
+
+/**
+ * To be used with Retrieve, Query, and QueryMore operations.
+ *
+ * @package SalesforceSoapClient
+ */
+class QueryOptions
+{
+    // int - Batch size for the number of records returned in a query or queryMore call. The default is 500; the minimum is 200, and the maximum is 2,000.
+    public $batchSize;
+
+    /**
+     * Constructor
+     *
+     * @param int $limit Batch size
+     */
+    public function __construct($limit)
+    {
+        $this->batchSize = $limit;
+    }
+}
+
+?>

--- a/src/ForceDotCom/Results/BasicResult.php
+++ b/src/ForceDotCom/Results/BasicResult.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace CEE\Salesforce\ForceDotCom\Results;
+
+use stdClass;
+
+class BasicResult {
+
+	/**
+	 * @var array<ResultError>
+	 */
+	public array $errors;
+	public string $id;
+	public bool $success;
+
+	public function __construct( stdClass $response ) {
+		$this->id = $response->id;
+		$this->success = $response->success;
+		foreach( $response->errors ?? [] as $error ) {
+			$this->errors[] = new ResultError( $error );
+		}
+	}
+
+	/**
+	 * @param array<stdClass> $results
+	 * @return array<BasicResult>
+	 */
+	public static function createMultiple( array $results ): array {
+		return array_map( fn( $result ) => new static( $result ), $results );
+	}
+}

--- a/src/ForceDotCom/Results/QueryResult.php
+++ b/src/ForceDotCom/Results/QueryResult.php
@@ -1,0 +1,119 @@
+<?php namespace CEE\Salesforce\ForceDotCom\Results;
+
+/*
+ * Copyright (c) 2007, salesforce.com, inc.
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification, are permitted provided
+* that the following conditions are met:
+*
+*    Redistributions of source code must retain the above copyright notice, this list of conditions and the
+*    following disclaimer.
+*
+*    Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+*    the following disclaimer in the documentation and/or other materials provided with the distribution.
+*
+*    Neither the name of salesforce.com, inc. nor the names of its contributors may be used to endorse or
+*    promote products derived from this software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+* WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+* PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+* ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+		* TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+* HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+		* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+use CEE\Salesforce\ForceDotCom\SforceBaseClient;
+use CEE\Salesforce\ForceDotCom\SObject;
+
+class QueryResult implements \Iterator
+{
+    public $queryLocator;
+    public $done;
+    public $records;
+    public $size;
+
+    public $pointer; // Current iterator location
+    private $sf; // SOAP Client
+
+    public function __construct($response)
+    {
+        $this->queryLocator = $response->queryLocator;
+        $this->done = $response->done;
+        $this->size = $response->size;
+
+        $this->pointer = 0;
+        $this->sf = false;
+
+        if ($response instanceof QueryResult) {
+            $this->records = $response->records;
+        } else {
+            $this->records = array();
+            if (isset($response->records)) {
+                if (is_array($response->records)) {
+                    foreach ($response->records as $record) {
+                        array_push($this->records, $record);
+                    }
+                } else {
+                    array_push($this->records, $record);
+                }
+            }
+        }
+    }
+
+    // Dependency Injection
+    public function setSf(SforceBaseClient $sf)
+    {
+        $this->sf = $sf;
+    }
+
+    // Basic Iterator implementation functions
+    public function rewind()
+    {
+        $this->pointer = 0;
+    }
+
+    public function next()
+    {
+        ++$this->pointer;
+    }
+
+    public function key()
+    {
+        return $this->pointer;
+    }
+
+    public function current()
+    {
+        return new SObject($this->records[$this->pointer]);
+    }
+
+    public function valid()
+    {
+        while ($this->pointer >= count($this->records)) {
+            // Pointer is larger than (current) result set; see if we can fetch more
+            if ($this->done === false) {
+                if ($this->sf === false) {
+                    throw new \Exception("Dependency not met!");
+                }
+                $response = $this->sf->queryMore($this->queryLocator);
+                $this->records = array_merge($this->records, $response->records); // Append more results
+                $this->done = $response->done;
+                $this->queryLocator = $response->queryLocator;
+            } else {
+                return false; // No more records to fetch
+            }
+        }
+
+        if (isset($this->records[$this->pointer])) {
+            return true;
+        }
+
+        throw new \Exception("QueryResult has gaps in the record data?");
+    }
+}
+
+?>

--- a/src/ForceDotCom/Results/ResultError.php
+++ b/src/ForceDotCom/Results/ResultError.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace CEE\Salesforce\ForceDotCom\Results;
+
+use stdClass;
+
+class ResultError {
+
+	public array $fields;
+	public string $message;
+	public string $statusCode;
+
+	public function __construct( stdClass $response ) {
+		$this->fields = $response->fields;
+		$this->message = $response->message;
+		$this->statusCode = $response->statusCode;
+	}
+}

--- a/src/ForceDotCom/SObject.php
+++ b/src/ForceDotCom/SObject.php
@@ -1,0 +1,292 @@
+<?php namespace CEE\Salesforce\ForceDotCom;
+
+/*
+ * Copyright (c) 2007, salesforce.com, inc.
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification, are permitted provided
+* that the following conditions are met:
+*
+*    Redistributions of source code must retain the above copyright notice, this list of conditions and the
+*    following disclaimer.
+*
+*    Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+*    the following disclaimer in the documentation and/or other materials provided with the distribution.
+*
+*    Neither the name of salesforce.com, inc. nor the names of its contributors may be used to endorse or
+*    promote products derived from this software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+* WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+* PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+* ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+		* TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+* HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+		* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+use CEE\Salesforce\ForceDotCom\Results\QueryResult;
+use Exception;
+use stdClass;
+
+class SObject
+{
+    public $type;
+    public $fields;
+
+    //	public $sobject;
+
+    public function __construct($response = null)
+    {
+        if (!isset($response) && !$response) {
+            return;
+        }
+
+        foreach ($response as $responseKey => $responseValue) {
+            if (in_array($responseKey, array('Id', 'type', 'any'))) {
+                continue;
+            }
+            $this->$responseKey = $responseValue;
+        }
+
+        if (isset($response->Id)) {
+            $this->Id = is_array($response->Id) ? $response->Id[0] : $response->Id;
+        }
+
+        if (isset($response->type)) {
+            $this->type = $response->type;
+        }
+
+        if (isset($response->any)) {
+            try {
+                if ($response->any instanceof stdClass) {
+                    if ($this->isSObject($response->any)) {
+                        $anArray = array();
+                        $sobject = new SObject($response->any);
+                        $anArray[] = $sobject;
+                        $this->sobjects = $anArray;
+                    } else {
+                        $this->queryResult = new QueryResult($response->any);
+                    }
+                } else {
+                    if (is_array($response->any)) {
+                        $anArray = array();
+                        foreach ($response->any as $key => $item) {
+                            if ($item instanceof stdClass) {
+                                if ($this->isSObject($item)) {
+                                    $sobject = new SObject($item);
+                                    $anArray[$key] = $sobject;
+                                } else {
+                                    if (!isset($this->queryResult)) {
+                                        $this->queryResult = array();
+                                    }
+                                    array_push($this->queryResult, new QueryResult($item));
+                                }
+                            } else {
+                                if (strpos($item, 'sf:') === false) {
+                                    $currentXmlValue = sprintf('<sf:%s>%s</sf:%s>', $key, $item, $key);
+                                } else {
+                                    $currentXmlValue = $item;
+                                }
+
+                                if (!isset($fieldsToConvert)) {
+                                    $fieldsToConvert = $currentXmlValue;
+                                } else {
+                                    $fieldsToConvert .= $currentXmlValue;
+                                }
+                            }
+                        }
+
+                        if (isset($fieldsToConvert)) {
+                            $this->fields = $this->convertFields($fieldsToConvert);
+                        }
+
+                        if (count($anArray) > 0) {
+                            foreach ($anArray as $key => $children_sobject) {
+                                $this->fields->$key = $children_sobject;
+                            }
+                        }
+                    } else {
+                        $this->fields = $this->convertFields($response->any);
+                    }
+                }
+            } catch (Exception $e) {
+                error_log('salesforce exception: ', $e->getMessage());
+                error_log('salesforce exception: ', $e->getTraceAsString());
+            }
+        }
+    }
+
+    public function __get($name)
+    {
+        return (isset($this->fields->$name)) ? $this->fields->$name : false;
+    }
+
+    public function __isset($name)
+    {
+        return isset($this->fields->$name);
+    }
+
+    /**
+     * Parse the "any" string from an sObject.  First strip out the sf: and then
+     * enclose string with <Object></Object>.  Load the string using
+     * simplexml_load_string and return an array that can be traversed.
+     */
+    public function convertFields($any)
+    {
+        $str = preg_replace('{sf:}', '', $any);
+
+        $array = $this->xml2array('<Object xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">' . $str . '</Object>',
+            2);
+
+        $xml = new stdClass();
+        if (!count($array['Object'])) {
+            return $xml;
+        }
+
+        foreach ($array['Object'] as $k => $v) {
+            $xml->$k = $v;
+        }
+
+        return $xml;
+    }
+
+    /**
+     *
+     * @param string $contents
+     * @return array
+     */
+    public function xml2array($contents, $get_attributes = 1)
+    {
+        if (!$contents) {
+            return array();
+        }
+
+        if (!function_exists('xml_parser_create')) {
+            return array('not found');
+        }
+
+        $parser = xml_parser_create();
+        xml_parser_set_option($parser, XML_OPTION_CASE_FOLDING, 0);
+        xml_parser_set_option($parser, XML_OPTION_SKIP_WHITE, 1);
+        xml_parse_into_struct($parser, $contents, $xml_values);
+        xml_parser_free($parser);
+
+        if (!$xml_values) {
+            return;
+        }
+
+        //Initializations
+        $xml_array = array();
+        $parents = array();
+        $opened_tags = array();
+        $arr = array();
+
+        $current = &$xml_array;
+
+        foreach ($xml_values as $data) {
+            unset($attributes, $value);//Remove existing values, or there will be trouble
+
+            //This command will extract these variables into the foreach scope
+            // tag(string), type(string), level(int), attributes(array).
+            extract($data);//We could use the array by itself, but this cooler.
+
+            $result = '';
+            if ($get_attributes) {
+                switch ($get_attributes) {
+                    case 1:
+                        $result = array();
+                        if (isset($value)) {
+                            $result['value'] = $value;
+                        }
+
+                        //Set the attributes too.
+                        if (isset($attributes)) {
+                            foreach ($attributes as $attr => $val) {
+                                if ($get_attributes == 1) {
+                                    $result['attr'][$attr] = $val;
+                                } //Set all the attributes in a array called 'attr'
+                                /**  :TODO: should we change the key name to '_attr'? Someone may use the tagname 'attr'. Same goes for 'value' too */
+                            }
+                        }
+                        break;
+
+                    case 2:
+                        $result = array();
+                        if (isset($value)) {
+                            $result = $value;
+                        }
+
+                        //Check for nil and ignore other attributes.
+                        if (isset($attributes) && isset($attributes['xsi:nil']) && !strcasecmp($attributes['xsi:nil'],
+                                'true')
+                        ) {
+                            $result = null;
+                        }
+                        break;
+                }
+            } elseif (isset($value)) {
+                $result = $value;
+            }
+
+            //See tag status and do the needed.
+            if ($type == "open") {//The starting of the tag '<tag>'
+                $parent[$level - 1] = &$current;
+
+                if (!is_array($current) || (!in_array($tag, array_keys($current)))) { //Insert New tag
+                    $current[$tag] = $result;
+                    $current = &$current[$tag];
+
+                } else { //There was another element with the same tag name
+                    if (isset($current[$tag][0])) {
+                        array_push($current[$tag], $result);
+                    } else {
+                        $current[$tag] = array($current[$tag], $result);
+                    }
+                    $last = count($current[$tag]) - 1;
+                    $current = &$current[$tag][$last];
+                }
+
+            } elseif ($type == "complete") { //Tags that ends in 1 line '<tag />'
+                //See if the key is already taken.
+                if (!isset($current[$tag])) { //New Key
+                    $current[$tag] = $result;
+
+                } else { //If taken, put all things inside a list(array)
+                    if ((is_array($current[$tag]) && $get_attributes == 0)//If it is already an array...
+                        || (isset($current[$tag][0]) && is_array($current[$tag][0]) && ($get_attributes == 1 || $get_attributes == 2))
+                    ) {
+                        array_push($current[$tag], $result); // ...push the new element into that array.
+                    } else { //If it is not an array...
+                        $current[$tag] = array(
+                            $current[$tag],
+                            $result
+                        ); //...Make it an array using using the existing value and the new value
+                    }
+                }
+
+            } elseif ($type == 'close') { //End of tag '</tag>'
+                $current = &$parent[$level - 1];
+            }
+        }
+
+        return ($xml_array);
+    }
+
+    /*
+     * If the stdClass has a done, we know it is a QueryResult
+    */
+    public function isQueryResult($param)
+    {
+        return isset($param->done);
+    }
+
+    /*
+     * If the stdClass has a type, we know it is an SObject
+    */
+    public function isSObject($param)
+    {
+        return isset($param->type);
+    }
+}

--- a/src/ForceDotCom/SforceBaseClient.php
+++ b/src/ForceDotCom/SforceBaseClient.php
@@ -1,0 +1,1048 @@
+<?php namespace CEE\Salesforce\ForceDotCom;
+
+    /*
+     * Copyright (c) 2007, salesforce.com, inc.
+     * All rights reserved.
+     *
+     * Redistribution and use in source and binary forms, with or without modification, are permitted provided
+     * that the following conditions are met:
+     *
+     *    Redistributions of source code must retain the above copyright notice, this list of conditions and the
+     *    following disclaimer.
+     *
+     *    Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+     *    the following disclaimer in the documentation and/or other materials provided with the distribution.
+     *
+     *    Neither the name of salesforce.com, inc. nor the names of its contributors may be used to endorse or
+     *    promote products derived from this software without specific prior written permission.
+     *
+     * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+     * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+     * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+     * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+     * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+     * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+     * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+     * POSSIBILITY OF SUCH DAMAGE.
+     */
+
+    /**
+     * This file contains one class.
+     * @package SalesforceSoapClient
+     */
+
+	use CEE\Salesforce\ForceDotCom\Results\BasicResult;
+	use CEE\Salesforce\ForceDotCom\Results\QueryResult;
+	use Exception;
+	use SoapClient;
+	use SoapHeader;
+	use SoapVar;
+	use stdClass;
+
+	/**
+ * SalesforceSoapClient
+ * @package SalesforceSoapClient
+ */
+class SforceBaseClient
+{
+    protected $sforce;
+    protected $sessionId;
+    protected $location;
+    protected $version = '27.0';
+
+    protected $namespace;
+
+    // Header Options
+    protected $callOptions;
+    protected $assignmentRuleHeader;
+    protected $emailHeader;
+    protected $loginScopeHeader;
+    protected $mruHeader;
+    protected $queryHeader;
+    protected $userTerritoryDeleteHeader;
+    protected $sessionHeader;
+
+    // new headers
+    protected $allowFieldTruncationHeader;
+    protected $localeOptions;
+    protected $packageVersionHeader;
+
+    protected function getSoapClient($wsdl, $options)
+    {
+        return new SoapClient($wsdl, $options);
+    }
+
+    public function getNamespace()
+    {
+        return $this->namespace;
+    }
+
+
+    // clientId specifies which application or toolkit is accessing the
+    // salesforce.com API. For applications that are certified salesforce.com
+    // solutions, replace this with the value provided by salesforce.com.
+    // Otherwise, leave this value as 'phpClient/1.0'.
+    protected $client_id;
+
+    public function printDebugInfo()
+    {
+        echo 'PHP Toolkit Version: ' . $this->version . PHP_EOL;
+        echo 'Current PHP version: ' . PHP_VERSION;
+        echo PHP_EOL;
+        echo 'SOAP enabled: ';
+        if (extension_loaded('soap')) {
+            echo 'True';
+        } else {
+            echo 'False';
+        }
+        echo PHP_EOL;
+        echo 'OpenSSL enabled: ';
+        if (extension_loaded('openssl')) {
+            echo 'True';
+        } else {
+            echo 'False';
+        }
+    }
+
+    /**
+     * Connect method to www.salesforce.com
+     *
+     * @param string $wsdl Salesforce.com Partner WSDL
+     * @param object $proxy (optional) proxy settings with properties host, port,
+     *                       login and password
+     * @param array $soap_options (optional) Additional options to send to the
+     *                       SoapClient constructor. @see
+     *                       http://php.net/manual/en/soapclient.soapclient.php
+     */
+    public function createConnection($wsdl, $proxy = null, $soap_options = array())
+    {
+        // use correct version comparison
+        if (version_compare(PHP_VERSION, '5.3', '<')) {
+            throw new Exception ('PHP versions older than 5.3 are no longer supported. Please upgrade!');
+        }
+
+        $soapClientArray = array_merge(array(
+            'user_agent' => 'salesforce-toolkit-php/' . $this->version,
+            'encoding' => 'utf-8',
+            'trace' => 1,
+            'features' => SOAP_SINGLE_ELEMENT_ARRAYS,
+            'compression' => SOAP_COMPRESSION_ACCEPT | SOAP_COMPRESSION_GZIP
+        ), $soap_options);
+
+
+        if ($proxy != null) {
+            $proxySettings = array();
+            $proxySettings['proxy_host'] = $proxy->host;
+            $proxySettings['proxy_port'] = $proxy->port; // Use an integer, not a string
+            $proxySettings['proxy_login'] = $proxy->login;
+            $proxySettings['proxy_password'] = $proxy->password;
+            $soapClientArray = array_merge($soapClientArray, $proxySettings);
+        }
+
+        $this->sforce = $this->getSoapClient($wsdl, $soapClientArray);
+
+        return $this->sforce;
+    }
+
+    public function setCallOptions($header)
+    {
+        if ($header != null) {
+            $this->callOptions = new SoapHeader($this->namespace, 'CallOptions', array(
+                'client' => $header->client,
+                'defaultNamespace' => $header->defaultNamespace
+            ));
+        } else {
+            $this->callOptions = null;
+        }
+    }
+
+    /**
+     * Login to Salesforce.com and starts a client session.
+     *
+     * @param string $username Username
+     * @param string $password Password
+     *
+     * @return stdClass LoginResult
+     */
+    public function login($username, $password)
+    {
+        $this->sforce->__setSoapHeaders(null);
+        if ($this->callOptions != null) {
+            $this->sforce->__setSoapHeaders(array($this->callOptions));
+        }
+        if ($this->loginScopeHeader != null) {
+            $this->sforce->__setSoapHeaders(array($this->loginScopeHeader));
+        }
+        $result = $this->sforce->login(array(
+            'username' => $username,
+            'password' => $password
+        ));
+        $result = $result->result;
+        $this->_setLoginHeader($result);
+
+        return $result;
+    }
+
+    /**
+     * log outs from the salseforce system`
+     *
+     * @return stdClass LogoutResult
+     */
+    public function logout()
+    {
+        $this->setHeaders("logout");
+        $arg = new stdClass();
+
+        return $this->sforce->logout();
+    }
+
+    /**
+     *invalidate Sessions from the salseforce system`
+     *
+     * @return stdClass InvalidateSessionsResult
+	 * @property array<stdClass> $errors Error
+	 * @property bool $success
+     */
+    public function invalidateSessions()
+    {
+        $this->setHeaders("invalidateSessions");
+        $arg = new stdClass();
+        $this->logout();
+
+        return $this->sforce->invalidateSessions();
+    }
+
+    /**
+     * Specifies the session ID returned from the login server after a successful
+     * login.
+     */
+    protected function _setLoginHeader($loginResult)
+    {
+        $this->sessionId = $loginResult->sessionId;
+        $this->setSessionHeader($this->sessionId);
+        $serverURL = $loginResult->serverUrl;
+        $this->setEndPoint($serverURL);
+    }
+
+    /**
+     * Set the endpoint.
+     *
+     * @param string $location Location
+     */
+    public function setEndpoint($location)
+    {
+        $this->location = $location;
+        $this->sforce->__setLocation($location);
+    }
+
+    private function setHeaders($call = null)
+    {
+        $this->sforce->__setSoapHeaders(null);
+
+        $header_array = array(
+            $this->sessionHeader
+        );
+
+        $header = $this->callOptions;
+        if ($header != null) {
+            array_push($header_array, $header);
+        }
+
+        if ($call == "create" ||
+            $call == "merge" ||
+            $call == "update" ||
+            $call == "upsert"
+        ) {
+            $header = $this->assignmentRuleHeader;
+            if ($header != null) {
+                array_push($header_array, $header);
+            }
+        }
+
+        if ($call == "login") {
+            $header = $this->loginScopeHeader;
+            if ($header != null) {
+                array_push($header_array, $header);
+            }
+        }
+
+        if ($call == "create" ||
+            $call == "resetPassword" ||
+            $call == "update" ||
+            $call == "upsert"
+        ) {
+            $header = $this->emailHeader;
+            if ($header != null) {
+                array_push($header_array, $header);
+            }
+        }
+
+        if ($call == "create" ||
+            $call == "merge" ||
+            $call == "query" ||
+            $call == "retrieve" ||
+            $call == "update" ||
+            $call == "upsert"
+        ) {
+            $header = $this->mruHeader;
+            if ($header != null) {
+                array_push($header_array, $header);
+            }
+        }
+
+        if ($call == "delete") {
+            $header = $this->userTerritoryDeleteHeader;
+            if ($header != null) {
+                array_push($header_array, $header);
+            }
+        }
+
+        if ($call == "query" ||
+            $call == "queryMore" ||
+            $call == "retrieve"
+        ) {
+            $header = $this->queryHeader;
+            if ($header != null) {
+                array_push($header_array, $header);
+            }
+        }
+
+        // try to add allowFieldTruncationHeader
+        $allowFieldTruncationHeaderCalls = array(
+            'convertLead',
+            'create',
+            'merge',
+            'process',
+            'undelete',
+            'update',
+            'upsert',
+        );
+        if (in_array($call, $allowFieldTruncationHeaderCalls)) {
+            $header = $this->allowFieldTruncationHeader;
+            if ($header != null) {
+                array_push($header_array, $header);
+            }
+        }
+
+        // try to add localeOptions
+        if ($call == 'describeSObject' || $call == 'describeSObjects') {
+            $header = $this->localeOptions;
+            if ($header != null) {
+                array_push($header_array, $header);
+            }
+        }
+
+        // try to add PackageVersionHeader
+        $packageVersionHeaderCalls = array(
+            'convertLead',
+            'create',
+            'delete',
+            'describeGlobal',
+            'describeLayout',
+            'describeSObject',
+            'describeSObjects',
+            'describeSoftphoneLayout',
+            'describeTabs',
+            'merge',
+            'process',
+            'query',
+            'retrieve',
+            'search',
+            'undelete',
+            'update',
+            'upsert',
+        );
+
+        if (in_array($call, $packageVersionHeaderCalls)) {
+            $header = $this->packageVersionHeader;
+            if ($header != null) {
+                array_push($header_array, $header);
+            }
+        }
+
+        $this->sforce->__setSoapHeaders($header_array);
+    }
+
+    public function setAssignmentRuleHeader($header)
+    {
+        if ($header != null) {
+            $this->assignmentRuleHeader = new SoapHeader($this->namespace, 'AssignmentRuleHeader', array(
+                'assignmentRuleId' => $header->assignmentRuleId,
+                'useDefaultRule' => $header->useDefaultRuleFlag
+            ));
+        } else {
+            $this->assignmentRuleHeader = null;
+        }
+    }
+
+    public function setEmailHeader($header)
+    {
+        if ($header != null) {
+            $this->emailHeader = new SoapHeader($this->namespace, 'EmailHeader', array(
+                'triggerAutoResponseEmail' => $header->triggerAutoResponseEmail,
+                'triggerOtherEmail' => $header->triggerOtherEmail,
+                'triggerUserEmail' => $header->triggerUserEmail
+            ));
+        } else {
+            $this->emailHeader = null;
+        }
+    }
+
+    public function setLoginScopeHeader($header)
+    {
+        if ($header != null) {
+            $this->loginScopeHeader = new SoapHeader($this->namespace, 'LoginScopeHeader', array(
+                'organizationId' => $header->organizationId,
+                'portalId' => $header->portalId
+            ));
+        } else {
+            $this->loginScopeHeader = null;
+        }
+    }
+
+    public function setMruHeader($header)
+    {
+        if ($header != null) {
+            $this->mruHeader = new SoapHeader($this->namespace, 'MruHeader', array(
+                'updateMru' => $header->updateMruFlag
+            ));
+        } else {
+            $this->mruHeader = null;
+        }
+    }
+
+    public function setSessionHeader($id)
+    {
+        if ($id != null) {
+            $this->sessionHeader = new SoapHeader($this->namespace, 'SessionHeader', array(
+                'sessionId' => $id
+            ));
+            $this->sessionId = $id;
+        } else {
+            $this->sessionHeader = null;
+            $this->sessionId = null;
+        }
+    }
+
+    public function setUserTerritoryDeleteHeader($header)
+    {
+        if ($header != null) {
+            $this->userTerritoryDeleteHeader = new SoapHeader($this->namespace, 'UserTerritoryDeleteHeader  ', array(
+                'transferToUserId' => $header->transferToUserId
+            ));
+        } else {
+            $this->userTerritoryDeleteHeader = null;
+        }
+    }
+
+    public function setQueryOptions($header)
+    {
+        if ($header != null) {
+            $this->queryHeader = new SoapHeader($this->namespace, 'QueryOptions', array(
+                'batchSize' => $header->batchSize
+            ));
+        } else {
+            $this->queryHeader = null;
+        }
+    }
+
+    public function setAllowFieldTruncationHeader($header)
+    {
+        if ($header != null) {
+            $this->allowFieldTruncationHeader = new SoapHeader($this->namespace, 'AllowFieldTruncationHeader', array(
+                    'allowFieldTruncation' => $header->allowFieldTruncation
+                )
+            );
+        } else {
+            $this->allowFieldTruncationHeader = null;
+        }
+    }
+
+    public function setLocaleOptions($header)
+    {
+        if ($header != null) {
+            $this->localeOptions = new SoapHeader($this->namespace, 'LocaleOptions',
+                array(
+                    'language' => $header->language
+                )
+            );
+        } else {
+            $this->localeOptions = null;
+        }
+    }
+
+    /**
+     * @param $header
+     */
+    public function setPackageVersionHeader($header)
+    {
+        if ($header != null) {
+            $headerData = array('packageVersions' => array());
+
+            foreach ($header->packageVersions as $key => $hdrElem) {
+                $headerData['packageVersions'][] = array(
+                    'majorNumber' => $hdrElem->majorNumber,
+                    'minorNumber' => $hdrElem->minorNumber,
+                    'namespace' => $hdrElem->namespace,
+                );
+            }
+
+            $this->packageVersionHeader = new SoapHeader($this->namespace,
+                'PackageVersionHeader',
+                $headerData
+            );
+        } else {
+            $this->packageVersionHeader = null;
+        }
+    }
+
+    public function getSessionId()
+    {
+        return $this->sessionId;
+    }
+
+    public function getLocation()
+    {
+        return $this->location;
+    }
+
+    public function getConnection()
+    {
+        return $this->sforce;
+    }
+
+    public function getFunctions()
+    {
+        return $this->sforce->__getFunctions();
+    }
+
+    public function getTypes()
+    {
+        return $this->sforce->__getTypes();
+    }
+
+    public function getLastRequest()
+    {
+        return $this->sforce->__getLastRequest();
+    }
+
+    public function getLastRequestHeaders()
+    {
+        return $this->sforce->__getLastRequestHeaders();
+    }
+
+    public function getLastResponse()
+    {
+        return $this->sforce->__getLastResponse();
+    }
+
+    public function getLastResponseHeaders()
+    {
+        return $this->sforce->__getLastResponseHeaders();
+    }
+
+    protected function _convertToAny($fields)
+    {
+        $anyString = '';
+        foreach ($fields as $key => $value) {
+            $anyString = $anyString . '<' . $key . '>' . $value . '</' . $key . '>';
+        }
+
+        return $anyString;
+    }
+
+	/**
+	 * @return array<BasicResult>
+	 */
+	protected function _create($arg): array
+    {
+        $this->setHeaders("create");
+
+        return BasicResult::createMultiple( $this->sforce->create($arg)->result );
+    }
+
+    protected function _merge($arg)
+    {
+        $this->setHeaders("merge");
+
+        return $this->sforce->merge($arg)->result;
+    }
+
+    protected function _process($arg)
+    {
+        $this->setHeaders();
+
+        return $this->sforce->process($arg)->result;
+    }
+
+	/**
+	 * @return array<BasicResult>
+	 */
+	protected function _update($arg): array
+    {
+        $this->setHeaders("update");
+
+        return BasicResult::createMultiple( $this->sforce->update($arg)->result );
+    }
+
+    protected function _upsert($arg)
+    {
+        $this->setHeaders("upsert");
+
+        return $this->sforce->upsert($arg)->result;
+    }
+
+    public function sendSingleEmail($request)
+    {
+        if (is_array($request)) {
+            $messages = array();
+            foreach ($request as $r) {
+                $email = new SoapVar($r, SOAP_ENC_OBJECT, 'SingleEmailMessage', $this->namespace);
+                array_push($messages, $email);
+            }
+            $arg = new stdClass();
+            $arg->messages = $messages;
+
+            return $this->_sendEmail($arg);
+        } else {
+            $backtrace = debug_backtrace();
+            error_log('Please pass in array to this function:  ' . $backtrace[0]['function']);
+            return false;
+        }
+    }
+
+    public function sendMassEmail($request)
+    {
+        if (is_array($request)) {
+            $messages = array();
+            foreach ($request as $r) {
+                $email = new SoapVar($r, SOAP_ENC_OBJECT, 'MassEmailMessage', $this->namespace);
+                array_push($messages, $email);
+            }
+            $arg = new stdClass();
+            $arg->messages = $messages;
+
+            return $this->_sendEmail($arg);
+        } else {
+            $backtrace = debug_backtrace();
+            error_log('Please pass in array to this function:  ' . $backtrace[0]['function']);
+            return false;
+        }
+    }
+
+    protected function _sendEmail($arg)
+    {
+        $this->setHeaders();
+
+        return $this->sforce->sendEmail($arg)->result;
+    }
+
+    /**
+     * Converts a Lead into an Account, Contact, or (optionally) an Opportunity.
+     *
+     * @param array $leadConverts Array of LeadConvert
+     *
+     * @return stdClass LeadConvertResult
+     */
+    public function convertLead($leadConverts)
+    {
+		$this->setHeaders("convertLead");
+        $arg = new stdClass();
+        
+        foreach ($leadConverts as $k => $lc) {
+            if (isset($lc->contactRecord) && !$lc->contactRecord instanceof SoapVar) {
+                $lc->contactRecord = new SoapVar($lc->contactRecord, SOAP_ENC_OBJECT, 'Contact', $this->namespace);
+            }
+
+            if (isset($lc->opportunityRecord) && !$lc->opportunityRecord instanceof SoapVar) {
+                $lc->opportunityRecord = new SoapVar($lc->opportunityRecord, SOAP_ENC_OBJECT, 'Opportunity', $this->namespace);
+            }
+
+            if (isset($lc->accountRecord) && !$lc->accountRecord instanceof SoapVar) {
+                $lc->accountRecord = new SoapVar($lc->accountRecord, SOAP_ENC_OBJECT, 'Account', $this->namespace);
+            }
+
+            $leadConverts[$k] = $lc;
+        }
+		
+        $arg->leadConverts = $leadConverts;
+        
+		return $this->sforce->convertLead($arg);
+	}
+
+    /**
+     * Deletes one or more new individual objects to your organization's data.
+	 *
+	 * @return array<BasicResult>
+     */
+	public function delete( array $ids ): array {
+		$this->setHeaders( "delete" );
+		$arg = new stdClass();
+		$arg->ids = $ids;
+
+		return BasicResult::createMultiple( $this->sforce->delete( $arg )->result );
+	}
+
+
+	/**
+	 * @return array<BasicResult>
+	 */
+	public function undelete( array $ids ): array {
+		$this->setHeaders( "undelete" );
+		$arg = new stdClass();
+		$arg->ids = $ids;
+
+		return BasicResult::createMultiple( $this->sforce->undelete( $arg )->result );
+	}
+
+	/**
+	 * @return array<BasicResult>
+	 */
+	public function emptyRecycleBin(array $ids): array {
+        $this->setHeaders();
+        $arg = new stdClass();
+        $arg->ids = $ids;
+
+        return BasicResult::createMultiple( $this->sforce->emptyRecycleBin($arg)->result );
+    }
+
+    /**
+     * Process Submit Request for Approval
+     *
+     * @param array $processRequestArray
+     * @return stdClass|bool (ProcessResult)
+     */
+    public function processSubmitRequest($processRequestArray)
+    {
+        if (is_array($processRequestArray)) {
+            foreach ($processRequestArray as &$process) {
+                $process = new SoapVar($process, SOAP_ENC_OBJECT, 'ProcessSubmitRequest', $this->namespace);
+            }
+            $arg = new stdClass();
+            $arg->actions = $processRequestArray;
+
+            return $this->_process($arg);
+        } else {
+            $backtrace = debug_backtrace();
+            error_log('Please pass in array to this function:  ' . $backtrace[0]['function']);
+            return false;
+        }
+    }
+
+    /**
+     * Process Work Item Request for Approval
+     *
+     * @param array $processRequestArray
+     * @return stdClass|bool (ProcessResult)
+     */
+    public function processWorkitemRequest($processRequestArray)
+    {
+        if (is_array($processRequestArray)) {
+            foreach ($processRequestArray as &$process) {
+                $process = new SoapVar($process, SOAP_ENC_OBJECT, 'ProcessWorkitemRequest', $this->namespace);
+            }
+            $arg = new stdClass();
+            $arg->actions = $processRequestArray;
+
+            return $this->_process($arg);
+        } else {
+            $backtrace = debug_backtrace();
+            error_log('Please pass in array to this function:  ' . $backtrace[0]['function']);
+            return false;
+        }
+    }
+
+    /**
+     * Retrieves a list of available objects for your organization's data.
+     *
+     * @return stdClass DescribeGlobalResult
+     */
+    public function describeGlobal()
+    {
+        $this->setHeaders("describeGlobal");
+
+        return $this->sforce->describeGlobal()->result;
+    }
+
+    /**
+     * Use describeLayout to retrieve information about the layout (presentation
+     * of data to users) for a given object type. The describeLayout call returns
+     * metadata about a given page layout, including layouts for edit and
+     * display-only views and record type mappings. Note that field-level security
+     * and layout editability affects which fields appear in a layout.
+     *
+     * @param string $type   Object Type
+     * @return stdClass DescribeLayoutResult
+     */
+    public function describeLayout($type, array $recordTypeIds = null)
+    {
+        $this->setHeaders("describeLayout");
+        $arg = new stdClass();
+        $arg->sObjectType = new SoapVar($type, XSD_STRING, 'string', 'http://www.w3.org/2001/XMLSchema');
+        if (isset($recordTypeIds) && count($recordTypeIds)) {
+            $arg->recordTypeIds = $recordTypeIds;
+        }
+
+        return $this->sforce->describeLayout($arg)->result;
+    }
+
+    /**
+     * Describes metadata (field list and object properties) for the specified
+     * object.
+     *
+     * @param string $type Object type
+     * @return stdClass DescribeSObjectResult
+     */
+    public function describeSObject($type)
+    {
+        $this->setHeaders("describeSObject");
+        $arg = new stdClass();
+        $arg->sObjectType = new SoapVar($type, XSD_STRING, 'string', 'http://www.w3.org/2001/XMLSchema');
+
+        return $this->sforce->describeSObject($arg)->result;
+    }
+
+    /**
+     * An array-based version of describeSObject; describes metadata (field list
+     * and object properties) for the specified object or array of objects.
+     *
+     * @param array $arrayOfTypes Array of object types.
+     * @return stdClass DescribeSObjectResult
+     */
+    public function describeSObjects($arrayOfTypes)
+    {
+        $this->setHeaders("describeSObjects");
+
+        return $this->sforce->describeSObjects($arrayOfTypes)->result;
+    }
+
+    /**
+     * The describeTabs call returns information about the standard apps and
+     * custom apps, if any, available for the user who sends the call, including
+     * the list of tabs defined for each app.
+     *
+     * @return stdClass DescribeTabSetResult
+     */
+    public function describeTabs()
+    {
+        $this->setHeaders("describeTabs");
+
+        return $this->sforce->describeTabs()->result;
+    }
+
+    /**
+     * To enable data categories groups you must enable Answers or Knowledge Articles module in
+     * admin panel, after adding category group and assign it to Answers or Knowledge Articles
+     *
+     * @param string $sObjectType sObject Type
+     * @return stdClass DescribeDataCategoryGroupResult
+     */
+    public function describeDataCategoryGroups($sObjectType)
+    {
+        $this->setHeaders('describeDataCategoryGroups');
+        $arg = new stdClass();
+        $arg->sObjectType = new SoapVar($sObjectType, XSD_STRING, 'string', 'http://www.w3.org/2001/XMLSchema');
+
+        return $this->sforce->describeDataCategoryGroups($arg)->result;
+    }
+
+    /**
+     * Retrieves available category groups along with their data category structure for objects specified in the request.
+     *
+     * @param array<stdClass> $pairs DataCategoryGroupSobjectTypePair
+     * @param bool $topCategoriesOnly Object Type
+     * @return stdClass DescribeLayoutResult
+     */
+    public function describeDataCategoryGroupStructures(array $pairs, $topCategoriesOnly)
+    {
+        $this->setHeaders('describeDataCategoryGroupStructures');
+        $arg = new stdClass();
+        $arg->pairs = $pairs;
+        $arg->topCategoriesOnly = new SoapVar($topCategoriesOnly, XSD_BOOLEAN, 'boolean',
+            'http://www.w3.org/2001/XMLSchema');
+
+        return $this->sforce->describeDataCategoryGroupStructures($arg)->result;
+    }
+
+    /**
+     * Retrieves the list of individual objects that have been deleted within the
+     * given timespan for the specified object.
+     *
+     * @param string $type Ojbect type
+     * @param string $startDate Start date
+     * @param string $endDate End Date
+     * @return stdClass GetDeletedResult
+     */
+    public function getDeleted($type, $startDate, $endDate)
+    {
+        $this->setHeaders("getDeleted");
+        $arg = new stdClass();
+        $arg->sObjectType = new SoapVar($type, XSD_STRING, 'string', 'http://www.w3.org/2001/XMLSchema');
+        $arg->startDate = $startDate;
+        $arg->endDate = $endDate;
+
+        return $this->sforce->getDeleted($arg)->result;
+    }
+
+    /**
+     * Retrieves the list of individual objects that have been updated (added or
+     * changed) within the given timespan for the specified object.
+     *
+     * @param string $type Ojbect type
+     * @param string $startDate Start date
+     * @param string $endDate End Date
+     * @return stdClass GetUpdatedResult
+     */
+    public function getUpdated($type, $startDate, $endDate)
+    {
+        $this->setHeaders("getUpdated");
+        $arg = new stdClass();
+        $arg->sObjectType = new SoapVar($type, XSD_STRING, 'string', 'http://www.w3.org/2001/XMLSchema');
+        $arg->startDate = $startDate;
+        $arg->endDate = $endDate;
+
+        return $this->sforce->getUpdated($arg)->result;
+    }
+
+    /**
+     * Executes a query against the specified object and returns data that matches
+     * the specified criteria.
+     *
+     * @param string $query Query String
+     * @param QueryOptions $queryOptions Batch size limit.  OPTIONAL
+     * @return QueryResult
+     */
+    public function query($query)
+    {
+        $this->setHeaders("query");
+        $raw = $this->sforce->query(array(
+            'queryString' => $query
+        ))->result;
+        $QueryResult = new QueryResult($raw);
+        $QueryResult->setSf($this); // Dependency Injection
+        return $QueryResult;
+    }
+
+    /**
+     * Retrieves the next batch of objects from a query.
+     *
+     * @param string $queryLocator Represents the server-side cursor that tracks the current processing location in the query result set.
+     * @param QueryOptions $queryOptions Batch size limit.  OPTIONAL
+     * @return QueryResult
+     */
+    public function queryMore($queryLocator)
+    {
+        $this->setHeaders("queryMore");
+        $arg = new stdClass();
+        $arg->queryLocator = $queryLocator;
+        $raw = $this->sforce->queryMore($arg)->result;
+        $QueryResult = new QueryResult($raw);
+        $QueryResult->setSf($this); // Dependency Injection
+        return $QueryResult;
+    }
+
+    /**
+     * Retrieves data from specified objects, whether or not they have been deleted.
+     *
+     * @param String $query Query String
+     * @param QueryOptions $queryOptions Batch size limit.  OPTIONAL
+     * @return QueryResult
+     */
+    public function queryAll($query, $queryOptions = null)
+    {
+        $this->setHeaders("queryAll");
+        $raw = $this->sforce->queryAll(array(
+            'queryString' => $query
+        ))->result;
+        $QueryResult = new QueryResult($raw);
+        $QueryResult->setSf($this); // Dependency Injection
+        return $QueryResult;
+    }
+
+
+    /**
+     * Retrieves one or more objects based on the specified object IDs.
+     *
+     * @param string $fieldList One or more fields separated by commas.
+     * @param string $sObjectType Object from which to retrieve data.
+     * @param array $ids Array of one or more IDs of the objects to retrieve.
+     * @return sObject[]
+     */
+    public function retrieve($fieldList, $sObjectType, $ids)
+    {
+        $this->setHeaders("retrieve");
+        $arg = new stdClass();
+        $arg->fieldList = $fieldList;
+        $arg->sObjectType = new SoapVar($sObjectType, XSD_STRING, 'string', 'http://www.w3.org/2001/XMLSchema');
+        $arg->ids = $ids;
+
+        return $this->sforce->retrieve($arg)->result;
+    }
+
+    /**
+     * Executes a text search in your organization's data.
+     *
+     * @param string $searchString Search string that specifies the text expression to search for.
+     * @return SforceSearchResult SearchResult
+     */
+    public function search($searchString)
+    {
+        $this->setHeaders("search");
+        $arg = new stdClass();
+        $arg->searchString = new SoapVar($searchString, XSD_STRING, 'string', 'http://www.w3.org/2001/XMLSchema');
+
+        return new SforceSearchResult($this->sforce->search($arg)->result);
+    }
+
+    /**
+     * Retrieves the current system timestamp (GMT) from the Web service.
+     *
+     * @return stdClass GetServerTimestampResult
+	 * @property string $timestamp
+     */
+    public function getServerTimestamp()
+    {
+        $this->setHeaders("getServerTimestamp");
+
+        return $this->sforce->getServerTimestamp()->result;
+    }
+
+    public function getUserInfo()
+    {
+        $this->setHeaders("getUserInfo");
+
+        return $this->sforce->getUserInfo()->result;
+    }
+
+    /**
+     * Sets the specified user's password to the specified value.
+     *
+     * @param string $userId ID of the User.
+     * @param string $password New password
+     */
+    public function setPassword($userId, $password)
+    {
+        $this->setHeaders("setPassword");
+        $arg = new stdClass();
+        $arg->userId = new SoapVar($userId, XSD_STRING, 'string', 'http://www.w3.org/2001/XMLSchema');
+        $arg->password = $password;
+
+        return $this->sforce->setPassword($arg);
+    }
+
+    /**
+     * Changes a user's password to a system-generated value.
+     *
+     * @param string $userId Id of the User
+     * @return stdClass ResetPasswordResult
+	 * @property string $password
+     */
+    public function resetPassword($userId)
+    {
+        $this->setHeaders("resetPassword");
+        $arg = new stdClass();
+        $arg->userId = new SoapVar($userId, XSD_STRING, 'string', 'http://www.w3.org/2001/XMLSchema');
+
+        return $this->sforce->resetPassword($arg)->result;
+    }
+}

--- a/src/ForceDotCom/SforceCustomField.php
+++ b/src/ForceDotCom/SforceCustomField.php
@@ -1,0 +1,172 @@
+<?php namespace CEE\Salesforce\ForceDotCom;
+
+/*
+ * Copyright (c) 2007, salesforce.com, inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided
+ * that the following conditions are met:
+ *
+ *    Redistributions of source code must retain the above copyright notice, this list of conditions and the
+ *    following disclaimer.
+ *
+ *    Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *    the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ *    Neither the name of salesforce.com, inc. nor the names of its contributors may be used to endorse or
+ *    promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+class SforceCustomField
+{
+    public function setCaseSensitive($caseSensitive)
+    {
+        $this->caseSensitive = $caseSensitive;
+    }
+
+    public function setDefaultValue($defaultValue)
+    {
+        $this->defaultValue = $defaultValue;
+    }
+
+    public function setDescription($description)
+    {
+        $this->description = $description;
+    }
+
+    public function setDisplayFormat($displayFormat)
+    {
+        $this->displayFormat = $displayFormat;
+    }
+
+    public function setExternalId($externalId)
+    {
+        $this->externalId = $externalId;
+    }
+
+    public function setFormula($formula)
+    {
+        $this->formula = $formula;
+    }
+
+    public function setFormulaTreatBlankAs($formulaTreatBlankAs)
+    {
+        $this->formulaTreatBlankAs = $formulaTreatBlankAs;
+    }
+
+    public function setFullName($fullName)
+    {
+        $this->fullName = $fullName;
+    }
+
+    public function setInlineHelpText($inlineHelpText)
+    {
+        $this->inlineHelpText = $inlineHelpText;
+    }
+
+    public function setLabel($label)
+    {
+        $this->label = $label;
+    }
+
+    public function setLength($length)
+    {
+        $this->length = $length;
+    }
+
+    public function setMaskChar($maskChar)
+    {
+        $this->maskChar = $maskChar;
+    }
+
+    public function setMaskType($maskType)
+    {
+        $this->maskType = $maskType;
+    }
+
+    public function setPicklist($picklist)
+    {
+        $this->picklist = $picklist;
+    }
+
+    public function setPopulateExistingRows($populateExistingRows)
+    {
+        $this->populateExistingRows = $populateExistingRows;
+    }
+
+    public function setPrecision($precision)
+    {
+        $this->precision = $precision;
+    }
+
+    public function setReferenceTo($referenceTo)
+    {
+        $this->referenceTo = $referenceTo;
+    }
+
+    public function setRelationshipName($relationshipName)
+    {
+        $this->relationshipName = $relationshipName;
+    }
+
+    public function setRequired($required)
+    {
+        $this->required = $required;
+    }
+
+    public function setScale($scale)
+    {
+        $this->scale = $scale;
+    }
+
+    public function setStartingNumber($startingNumber)
+    {
+        $this->startingNumber = $startingNumber;
+    }
+
+    public function setSummarizeField($summarizeField)
+    {
+        $this->summarizeField = $summarizeField;
+    }
+
+    public function setSummaryFilterItems($summaryFilterItems)
+    {
+        $this->summaryFilterItems = $summaryFilterItems;
+    }
+
+    public function setSummaryForeignKey($summaryForeignKey)
+    {
+        $this->summaryForeignKey = $summaryForeignKey;
+    }
+
+    public function setSummaryOperation($summaryOperation)
+    {
+        $this->summaryOperation = $summaryOperation;
+    }
+
+    public function setType($type)
+    {
+        $this->type = $type;
+    }
+
+    public function setUnique($unique)
+    {
+        $this->unique = $unique;
+    }
+
+    public function setVisibleLines($visibleLines)
+    {
+        $this->visibleLines = $visibleLines;
+    }
+}
+
+?>

--- a/src/ForceDotCom/SforceCustomObject.php
+++ b/src/ForceDotCom/SforceCustomObject.php
@@ -1,0 +1,107 @@
+<?php namespace CEE\Salesforce\ForceDotCom;
+
+/*
+ * Copyright (c) 2007, salesforce.com, inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided
+ * that the following conditions are met:
+ *
+ *    Redistributions of source code must retain the above copyright notice, this list of conditions and the
+ *    following disclaimer.
+ *
+ *    Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *    the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ *    Neither the name of salesforce.com, inc. nor the names of its contributors may be used to endorse or
+ *    promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+class SforceCustomObject
+{
+    public function setDeploymentStatus($deploymentStatus)
+    {
+        $this->deploymentStatus = $deploymentStatus;
+    }
+
+    public function setDescription($description)
+    {
+        $this->description = $description;
+    }
+
+    public function setEnableActivities($enableActivities)
+    {
+        $this->enableActivities = $enableActivities;
+    }
+
+    public function setEnableDivisions($enableDivisions)
+    {
+        $this->enableDivisions = $enableDivisions;
+    }
+
+    public function setEnableHistory($enableHistory)
+    {
+        $this->enableHistory = $enableHistory;
+    }
+
+    public function setEnableReports($enableReports)
+    {
+        $this->enableReports = $enableReports;
+    }
+
+    public function setFields($fields)
+    {
+        $this->fields = $fields;
+    }
+
+    public function setFullName($fullName)
+    {
+        $this->fullName = $fullName;
+    }
+
+    public function setGender($gender)
+    {
+        $this->gender = $gender;
+    }
+
+    public function setHousehold($household)
+    {
+        $this->household = $household;
+    }
+
+    public function setLabel($label)
+    {
+        $this->label = $label;
+    }
+
+    public function setNameField($nameField)
+    {
+        $this->nameField = $nameField;
+    }
+
+    public function setPluralLabel($pluralLabel)
+    {
+        $this->pluralLabel = $pluralLabel;
+    }
+
+    public function setSharingModel($sharingModel)
+    {
+        $this->sharingModel = $sharingModel;
+    }
+
+    public function setStartsWith($startsWith)
+    {
+        $this->startsWith = $startsWith;
+    }
+}
+
+?>

--- a/src/ForceDotCom/SforceEnterpriseClient.php
+++ b/src/ForceDotCom/SforceEnterpriseClient.php
@@ -1,0 +1,167 @@
+<?php namespace CEE\Salesforce\ForceDotCom;
+
+    /*
+     * Copyright (c) 2007, salesforce.com, inc.
+     * All rights reserved.
+     *
+     * Redistribution and use in source and binary forms, with or without modification, are permitted provided
+     * that the following conditions are met:
+     *
+     *    Redistributions of source code must retain the above copyright notice, this list of conditions and the
+     *    following disclaimer.
+     *
+     *    Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+     *    the following disclaimer in the documentation and/or other materials provided with the distribution.
+     *
+     *    Neither the name of salesforce.com, inc. nor the names of its contributors may be used to endorse or
+     *    promote products derived from this software without specific prior written permission.
+     *
+     * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+     * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+     * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+     * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+     * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+     * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+     * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+     * POSSIBILITY OF SUCH DAMAGE.
+     */
+
+    /**
+     * This file contains two classes.
+     * @package SalesforceSoapClient
+     */
+
+use SoapParam;
+use SoapVar;
+use stdClass;
+
+/**
+ * SforceEnterpriseClient class.
+ *
+ * @package SalesforceSoapClient
+ */
+class SforceEnterpriseClient extends SforceBaseClient
+{
+    const ENTERPRISE_NAMESPACE = 'urn:enterprise.soap.sforce.com';
+
+    public function __construct()
+    {
+        $this->namespace = self::ENTERPRISE_NAMESPACE;
+    }
+
+	/**
+	 * Adds one or more new individual objects to your organization's data.
+	 *
+	 * @param array $sObjects Array of one or more sObjects (up to 200) to create.
+	 * @param string $type
+	 * @return array<stdClass>
+	 */
+    public function create(array $sObjects, string $type): array {
+        $arg = [];
+        foreach ($sObjects as $sObject) {
+            // FIX for fieldsToNull issue - allow array in fieldsToNull (STEP #1)
+            $xmlStr = '';
+            if (isset($sObject->fieldsToNull) && is_array($sObject->fieldsToNull)) {
+                foreach ($sObject->fieldsToNull as $fieldToNull) {
+                    $xmlStr .= '<fieldsToNull>' . $fieldToNull . '</fieldsToNull>';
+                }
+            }
+
+            $soapObject = new SoapVar($sObject, SOAP_ENC_OBJECT, $type, $this->namespace);
+
+            // FIX for fieldsToNull issue - allow array in fieldsToNull (STEP #2)
+            if ($xmlStr != '') {
+                $soapObject->enc_value->fieldsToNull = new SoapVar(new SoapVar($xmlStr, XSD_ANYXML), SOAP_ENC_ARRAY);
+            }
+            $arg[] = $soapObject;
+        }
+
+        return parent::_create(new SoapParam($arg, "sObjects"));
+    }
+
+	/**
+	 * Updates one or more new individual objects to your organization's data.
+	 *
+	 * @param array $sObjects Array of sObjects
+	 * @param string $type
+	 * @return array<stdClass> <SaveResult>
+	 */
+    public function update( array $sObjects, string $type ): array {
+        $arg = new stdClass;
+        $arg->sObjects = [];
+        foreach ($sObjects as $sObject) {
+            // FIX for fieldsToNull issue - allow array in fieldsToNull (STEP #1)
+            $xmlStr = '';
+            if (isset($sObject->fieldsToNull) && is_array($sObject->fieldsToNull)) {
+                foreach ($sObject->fieldsToNull as $fieldToNull) {
+                    $xmlStr .= '<fieldsToNull>' . $fieldToNull . '</fieldsToNull>';
+                }
+            }
+
+            $soapObject = new SoapVar($sObject, SOAP_ENC_OBJECT, $type, $this->namespace);
+
+            // FIX for fieldsToNull issue - allow array in fieldsToNull (STEP #2)
+            if ($xmlStr != '') {
+                $soapObject->enc_value->fieldsToNull = new SoapVar(new SoapVar($xmlStr, XSD_ANYXML), SOAP_ENC_ARRAY);
+            }
+            $arg->sObjects[] = $soapObject;
+        }
+
+        return parent::_update($arg);
+    }
+
+    /**
+     * Creates new objects and updates existing objects; uses a custom field to
+     * determine the presence of existing objects. In most cases, we recommend
+     * that you use upsert instead of create because upsert is idempotent.
+     * Available in the API version 7.0 and later.
+     *
+     * @param string $ext_Id External Id
+     * @param array $sObjects Array of sObjects
+     * @param string $type The type of objects being upserted.
+     * @return array <UpsertResult>
+     */
+    public function upsert($ext_Id, $sObjects, $type = 'Contact')
+    {
+        $arg = new stdClass;
+        $arg->sObjects = [];
+        $arg->externalIDFieldName = new SoapVar($ext_Id, XSD_STRING, 'string', 'http://www.w3.org/2001/XMLSchema');
+
+        foreach ($sObjects as $sObject) {
+            // FIX for fieldsToNull issue - allow array in fieldsToNull (STEP #1)
+            $xmlStr = '';
+            if (isset($sObject->fieldsToNull) && is_array($sObject->fieldsToNull)) {
+                foreach ($sObject->fieldsToNull as $fieldToNull) {
+                    $xmlStr .= '<fieldsToNull>' . $fieldToNull . '</fieldsToNull>';
+                }
+            }
+
+            $soapObject = new SoapVar($sObject, SOAP_ENC_OBJECT, $type, $this->namespace);
+
+            // FIX for fieldsToNull issue - allow array in fieldsToNull (STEP #2)
+            if ($xmlStr != '') {
+                $soapObject->enc_value->fieldsToNull = new SoapVar(new SoapVar($xmlStr, XSD_ANYXML), SOAP_ENC_ARRAY);
+            }
+            $arg->sObjects[] = $soapObject;
+        }
+
+        return parent::_upsert($arg);
+    }
+
+    /**
+     * Merge records
+     *
+     * @param stdclass $mergeRequest
+     * @param String $type
+     * @return unknown
+     */
+    public function merge($mergeRequest, $type)
+    {
+        $mergeRequest->masterRecord = new SoapVar($mergeRequest->masterRecord, SOAP_ENC_OBJECT, $type,
+            $this->namespace);
+        $arg = new stdClass;
+        $arg->request = new SoapVar($mergeRequest, SOAP_ENC_OBJECT, 'MergeRequest', $this->namespace);
+
+        return parent::_merge($arg);
+    }
+}

--- a/src/ForceDotCom/SforceFieldTypes.php
+++ b/src/ForceDotCom/SforceFieldTypes.php
@@ -1,0 +1,50 @@
+<?php namespace CEE\Salesforce\ForceDotCom;
+
+/*
+ * Copyright (c) 2007, salesforce.com, inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided
+ * that the following conditions are met:
+ *
+ *    Redistributions of source code must retain the above copyright notice, this list of conditions and the
+ *    following disclaimer.
+ *
+ *    Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *    the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ *    Neither the name of salesforce.com, inc. nor the names of its contributors may be used to endorse or
+ *    promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+class SforceFieldTypes
+{
+    const DEPLOYMENT_STATUS_INDEVELOPMENT = 'InDevelopment';
+    const DEPLOYMENT_STATUS_DEPLOYED = 'Deployed';
+
+    const GENDER_NEUTER = 'Neuter';
+    const GENDER_MASCULINE = 'Masculine';
+    const GENDER_FEMININE = 'Feminine';
+
+    const SHARING_MODEL_PRIVATE = 'Private';
+    const SHARING_MODEL_READ = 'Read';
+    const SHARING_MODEL_READWRITE = 'ReadWrite';
+
+    const STARTS_WITH_CONSONANT = 'Consonant';
+    const STARTS_WITH_VOWEL = 'Vowel';
+    const STARTS_WITH_SPECIAL = 'Special';
+
+    const TREAT_BLANKS_AS_BLANK = 'BlankAsBlank';
+    const TREAT_BLANKS_AS_ZERO = 'BlankAsZero';
+}
+
+?>

--- a/src/ForceDotCom/SforceMetadataClient.php
+++ b/src/ForceDotCom/SforceMetadataClient.php
@@ -1,0 +1,187 @@
+<?php namespace CEE\Salesforce\ForceDotCom;
+/*
+ * Copyright (c) 2007, salesforce.com, inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided
+ * that the following conditions are met:
+ *
+ *    Redistributions of source code must retain the above copyright notice, this list of conditions and the
+ *    following disclaimer.
+ *
+ *    Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *    the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ *    Neither the name of salesforce.com, inc. nor the names of its contributors may be used to endorse or
+ *    promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+use SoapClient;
+use SoapHeader;
+use SoapVar;
+use stdClass;
+
+class SforceMetadataClient
+{
+    public $sforce;
+    protected $sessionId;
+    protected $location;
+    protected $version = '27.0';
+
+    protected $namespace = 'http://soap.sforce.com/2006/04/metadata';
+
+    public function __construct($wsdl, $loginResult, $sforceConn)
+    {
+        $soapClientArray = null;
+
+        $phpversion = substr(PHP_VERSION, 0, strpos(PHP_VERSION, '-'));
+        if ($phpversion > '5.1.2') {
+            $soapClientArray = array(
+                'user_agent' => 'salesforce-toolkit-php/' . $this->version,
+                'encoding' => 'utf-8',
+                'trace' => 1,
+                'compression' => SOAP_COMPRESSION_ACCEPT | SOAP_COMPRESSION_GZIP,
+                'sessionId' => $loginResult->sessionId
+            );
+        } else {
+            $soapClientArray = array(
+                'user_agent' => 'salesforce-toolkit-php/' . $this->version,
+                'encoding' => 'utf-8',
+                'trace' => 1,
+                'sessionId' => $loginResult->sessionId
+            );
+        }
+
+        $this->sforce = new SoapClient($wsdl, $soapClientArray);
+
+        $sessionVar = array(
+            'sessionId' => new SoapVar($loginResult->sessionId, XSD_STRING)
+        );
+
+        $headerBody = new SoapVar($sessionVar, SOAP_ENC_OBJECT);
+
+        $session_header = new SoapHeader($this->namespace, 'SessionHeader', $headerBody, false);
+
+        $header_array = array(
+            $session_header
+        );
+
+        $this->sforce->__setSoapHeaders($header_array);
+        $this->sforce->__setLocation($loginResult->metadataServerUrl);
+
+        return $this->sforce;
+    }
+
+    /**
+     * Specifies the session ID returned from the login server after a successful
+     * login.
+     */
+    protected function _setLoginHeader($loginResult)
+    {
+        $this->sessionId = $loginResult->sessionId;
+        $this->setSessionHeader($this->sessionId);
+        $serverURL = $loginResult->serverUrl;
+        $this->setEndPoint($serverURL);
+    }
+
+    /**
+     * Set the endpoint.
+     *
+     * @param string $location Location
+     */
+    public function setEndpoint($location)
+    {
+        $this->location = $location;
+        $this->sforce->__setLocation($location);
+    }
+
+    /**
+     * Set the Session ID
+     *
+     * @param string $sessionId Session ID
+     */
+    public function setSessionHeader($sessionId)
+    {
+        $this->sforce->__setSoapHeaders(null);
+        $session_header = new SoapHeader($this->namespace, 'SessionHeader', array(
+            'sessionId' => $sessionId
+        ));
+        $this->sessionId = $sessionId;
+        $header_array = array(
+            $session_header
+        );
+        $this->_setClientId($header_array);
+        $this->sforce->__setSoapHeaders($header_array);
+    }
+
+    private function getObjtype($obj)
+    {
+        $classArray = explode('\\', get_class($obj));
+        $objtype = array_pop($classArray);
+        if (strpos($objtype, 'Sforce', 0) === 0) {
+            $objtype = substr($objtype, 6);
+        }
+
+        return $objtype;
+    }
+
+    public function create($obj)
+    {
+        $encodedObj = new stdClass();
+        $encodedObj->metadata = new SoapVar($obj, SOAP_ENC_OBJECT, $this->getObjtype($obj), $this->namespace);
+
+        return $this->sforce->create($encodedObj);
+    }
+
+    public function update($obj)
+    {
+        $encodedObj = new stdClass();
+        $encodedObj->UpdateMetadata = $obj;
+        $encodedObj->UpdateMetadata->metadata = new SoapVar($obj->metadata, SOAP_ENC_OBJECT,
+            $this->getObjtype($obj->metadata), $this->namespace);
+
+        return $this->sforce->update($encodedObj);
+    }
+
+    public function delete($obj)
+    {
+        $encodedObj = new stdClass();
+        $encodedObj->metadata = new SoapVar($obj, SOAP_ENC_OBJECT, $this->getObjtype($obj), $this->namespace);
+
+        return $this->sforce->delete($encodedObj);
+    }
+
+    public function checkStatus($ids)
+    {
+        return $this->sforce->checkStatus($ids);
+    }
+
+    public function getLastRequest()
+    {
+        return $this->sforce->__getLastRequest();
+    }
+
+    public function getLastRequestHeaders()
+    {
+        return $this->sforce->__getLastRequestHeaders();
+    }
+
+    public function getLastResponse()
+    {
+        return $this->sforce->__getLastResponse();
+    }
+
+    public function getLastResponseHeaders()
+    {
+        return $this->sforce->__getLastResponseHeaders();
+    }
+}

--- a/src/ForceDotCom/SforcePartnerClient.php
+++ b/src/ForceDotCom/SforcePartnerClient.php
@@ -1,0 +1,206 @@
+<?php namespace CEE\Salesforce\ForceDotCom;
+
+    /*
+     * Copyright (c) 2007, salesforce.com, inc.
+     * All rights reserved.
+     *
+     * Redistribution and use in source and binary forms, with or without modification, are permitted provided
+     * that the following conditions are met:
+     *
+     *    Redistributions of source code must retain the above copyright notice, this list of conditions and the
+     *    following disclaimer.
+     *
+     *    Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+     *    the following disclaimer in the documentation and/or other materials provided with the distribution.
+     *
+     *    Neither the name of salesforce.com, inc. nor the names of its contributors may be used to endorse or
+     *    promote products derived from this software without specific prior written permission.
+     *
+     * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+     * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+     * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+     * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+     * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+     * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+     * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+     * POSSIBILITY OF SUCH DAMAGE.
+     */
+use stdClass;
+
+/**
+ * SforcePartnerClient class.
+ *
+ * @package SalesforceSoapClient
+ */
+class SforcePartnerClient extends SforceBaseClient
+{
+    const PARTNER_NAMESPACE = 'urn:partner.soap.sforce.com';
+
+    public function __construct()
+    {
+        $this->namespace = self::PARTNER_NAMESPACE;
+    }
+
+    protected function getSoapClient($wsdl, $options)
+    {
+        return new SforceSoapClient($wsdl, $options);
+    }
+
+    /**
+     * Adds one or more new individual objects to your organization's data.
+     * @param array $sObjects Array of one or more sObjects (up to 200) to create.
+     * @return SaveResult
+     */
+    public function create($sObjects)
+    {
+        $arg = new stdClass;
+        foreach ($sObjects as $sObject) {
+            if (isset ($sObject->fields)) {
+                $sObject->any = $this->_convertToAny($sObject->fields);
+            }
+        }
+        $arg->sObjects = $sObjects;
+
+        return parent::_create($arg);
+    }
+
+    /**
+     * Merge records
+     *
+     * @param stdclass $mergeRequest
+     * @param String $type
+     * @return mixed
+     */
+    public function merge($mergeRequest)
+    {
+        if (isset($mergeRequest->masterRecord)) {
+            if (isset($mergeRequest->masterRecord->fields)) {
+                $mergeRequest->masterRecord->any = $this->_convertToAny($mergeRequest->masterRecord->fields);
+            }
+            $arg = new stdClass();
+            $arg->request = $mergeRequest;
+
+            return $this->_merge($arg);
+        }
+    }
+
+    /**
+     *
+     * @param array $request
+     */
+    public function sendSingleEmail($request)
+    {
+        if (is_array($request)) {
+            $messages = array();
+            foreach ($request as $r) {
+                $email = new \SoapVar($r, SOAP_ENC_OBJECT, 'SingleEmailMessage', $this->namespace);
+                array_push($messages, $email);
+            }
+            $arg->messages = $messages;
+
+            return parent::_sendEmail($arg);
+        } else {
+            $backtrace = debug_backtrace();
+            error_log('Please pass in array to this function:  ' . $backtrace[0]['function']);
+            return false;
+        }
+    }
+
+    /**
+     *
+     * @param array $request
+     */
+    public function sendMassEmail($request)
+    {
+        $arg = new stdClass();
+        if (is_array($request)) {
+            $messages = array();
+            foreach ($request as $r) {
+                $email = new \SoapVar($r, SOAP_ENC_OBJECT, 'MassEmailMessage', $this->namespace);
+                array_push($messages, $email);
+            }
+            $arg->messages = $messages;
+
+            return parent::_sendEmail($arg);
+        } else {
+            $backtrace = debug_backtrace();
+            error_log('Please pass in array to this function:  ' . $backtrace[0]['function']);
+            return false;
+        }
+    }
+
+    /**
+     * Updates one or more new individual objects to your organization's data.
+     * @param array sObjects    Array of sObjects
+     * @return UpdateResult
+     */
+    public function update($sObjects)
+    {
+        $arg = new stdClass;
+        foreach ($sObjects as $sObject) {
+            if (isset($sObject->fields)) {
+                $sObject->any = $this->_convertToAny($sObject->fields);
+            }
+        }
+        $arg->sObjects = $sObjects;
+
+        return parent::_update($arg);
+    }
+
+    /**
+     * Creates new objects and updates existing objects; uses a custom field to
+     * determine the presence of existing objects. In most cases, we recommend
+     * that you use upsert instead of create because upsert is idempotent.
+     * Available in the API version 7.0 and later.
+     *
+     * @param string $ext_Id External Id
+     * @param array $sObjects Array of sObjects
+     * @return UpsertResult
+     */
+    public function upsert($ext_Id, $sObjects)
+    {
+        $arg = new stdClass;
+        $arg->externalIDFieldName = new \SoapVar($ext_Id, XSD_STRING, 'string', 'http://www.w3.org/2001/XMLSchema');
+        foreach ($sObjects as $sObject) {
+            if (isset ($sObject->fields)) {
+                $sObject->any = $this->_convertToAny($sObject->fields);
+            }
+        }
+        $arg->sObjects = $sObjects;
+
+        return parent::_upsert($arg);
+    }
+
+    /**
+     * @param string $fieldList
+     * @param string $sObjectType
+     * @param array $ids
+     * @return string
+     */
+    public function retrieve($fieldList, $sObjectType, $ids)
+    {
+        return $this->_retrieveResult(parent::retrieve($fieldList, $sObjectType, $ids));
+    }
+
+    /**
+     *
+     * @param mixed $response
+     * @return array
+     */
+    private function _retrieveResult($response)
+    {
+        $arr = array();
+        if (is_array($response)) {
+            foreach ($response as $r) {
+                $sobject = new SObject($r);
+                array_push($arr, $sobject);
+            }
+        } else {
+            $sobject = new SObject($response);
+            array_push($arr, $sobject);
+        }
+
+        return $arr;
+    }
+
+}

--- a/src/ForceDotCom/SforceSearchResult.php
+++ b/src/ForceDotCom/SforceSearchResult.php
@@ -1,0 +1,54 @@
+<?php namespace CEE\Salesforce\ForceDotCom;
+
+/*
+ * Copyright (c) 2007, salesforce.com, inc.
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification, are permitted provided
+* that the following conditions are met:
+*
+*    Redistributions of source code must retain the above copyright notice, this list of conditions and the
+*    following disclaimer.
+*
+*    Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+*    the following disclaimer in the documentation and/or other materials provided with the distribution.
+*
+*    Neither the name of salesforce.com, inc. nor the names of its contributors may be used to endorse or
+*    promote products derived from this software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+* WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+* PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+* ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+		* TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+* HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+		* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+class SforceSearchResult
+{
+    public $searchRecords;
+
+    public function __construct($response)
+    {
+        if ($response instanceof SforceSearchResult) {
+            $this->searchRecords = $response->searchRecords;
+        } else {
+            $this->searchRecords = array();
+            if (isset($response->searchRecords)) {
+                if (is_array($response->searchRecords)) {
+                    foreach ($response->searchRecords as $record) {
+                        $sobject = new SObject($record->record);
+                        array_push($this->searchRecords, $sobject);
+                    }
+                } else {
+                    $sobject = new SObject($response->searchRecords->record);
+                    array_push($this->records, $sobject);
+                }
+            }
+        }
+    }
+}
+
+?>

--- a/src/ForceDotCom/SforceSoapClient.php
+++ b/src/ForceDotCom/SforceSoapClient.php
@@ -1,0 +1,65 @@
+<?php namespace CEE\Salesforce\ForceDotCom;
+
+    /*
+     * Copyright (c) 2007, salesforce.com, inc.
+     * All rights reserved.
+     *
+     * Redistribution and use in source and binary forms, with or without modification, are permitted provided
+     * that the following conditions are met:
+     *
+     *    Redistributions of source code must retain the above copyright notice, this list of conditions and the
+     *    following disclaimer.
+     *
+     *    Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+     *    the following disclaimer in the documentation and/or other materials provided with the distribution.
+     *
+     *    Neither the name of salesforce.com, inc. nor the names of its contributors may be used to endorse or
+     *    promote products derived from this software without specific prior written permission.
+     *
+     * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+     * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+     * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+     * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+     * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+     * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+     * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+     * POSSIBILITY OF SUCH DAMAGE.
+     */
+
+    /**
+     * SforceSoapClient class.
+     *
+     * @package SalesforceSoapClient
+     */
+// When parsing partner WSDL, when PHP SOAP sees NewValue and OldValue, since
+// the element has a xsi:type attribute with value 'string', it drops the
+// string content into the parsed output and loses the tag name. Removing the
+// xsi:type forces PHP SOAP to just leave the tags intact
+class SforceSoapClient extends \SoapClient
+{
+    public function __doRequest($request, $location, $action, $version, $one_way = 0)
+    {
+        $response = parent::__doRequest($request, $location, $action, $version, $one_way);
+
+        if (strpos($response, '<sf:OldValue') === false && strpos($response, '<sf:NewValue') === false) {
+            return $response;
+        }
+
+        $dom = new \DOMDocument();
+        $dom->loadXML($response);
+
+        $nodeList = $dom->getElementsByTagName('NewValue');
+        foreach ($nodeList as $key => $node) {
+            $node->removeAttributeNS('http://www.w3.org/2001/XMLSchema-instance', 'type');
+        }
+
+        $nodeList = $dom->getElementsByTagName('OldValue');
+        foreach ($nodeList as $key => $node) {
+            $node->removeAttributeNS('http://www.w3.org/2001/XMLSchema-instance', 'type');
+        }
+
+        return $dom->saveXML();
+    }
+}
+
+?>

--- a/src/ForceDotCom/SingleEmailMessage.php
+++ b/src/ForceDotCom/SingleEmailMessage.php
@@ -1,0 +1,96 @@
+<?php namespace CEE\Salesforce\ForceDotCom;
+
+/*
+ * Copyright (c) 2007, salesforce.com, inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided
+ * that the following conditions are met:
+ *
+ *    Redistributions of source code must retain the above copyright notice, this list of conditions and the
+ *    following disclaimer.
+ *
+ *    Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *    the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ *    Neither the name of salesforce.com, inc. nor the names of its contributors may be used to endorse or
+ *    promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+class SingleEmailMessage extends Email
+{
+    public $ccAddresses;
+
+    public function __construct()
+    {
+
+    }
+
+    public function setBccAddresses($addresses)
+    {
+        $this->bccAddresses = $addresses;
+    }
+
+    public function setCcAddresses($addresses)
+    {
+        $this->ccAddresses = $addresses;
+    }
+
+    public function setCharset($charset)
+    {
+        $this->charset = $charset;
+    }
+
+    public function setHtmlBody($htmlBody)
+    {
+        $this->htmlBody = $htmlBody;
+    }
+
+    public function setOrgWideEmailAddressId($orgWideEmailAddressId)
+    {
+        $this->orgWideEmailAddressId = $orgWideEmailAddressId;
+    }
+
+    public function setPlainTextBody($plainTextBody)
+    {
+        $this->plainTextBody = $plainTextBody;
+    }
+
+    public function setTargetObjectId($targetObjectId)
+    {
+        $this->targetObjectId = $targetObjectId;
+    }
+
+    public function setTemplateId($templateId)
+    {
+        $this->templateId = $templateId;
+    }
+
+    public function setToAddresses($array)
+    {
+        $this->toAddresses = $array;
+    }
+
+    public function setWhatId($whatId)
+    {
+        $this->whatId = $whatId;
+    }
+
+    public function setFileAttachments($array)
+    {
+        $this->fileAttachments = $array;
+    }
+
+    public function setDocumentAttachments($array)
+    {
+        $this->documentAttachments = $array;
+    }
+}

--- a/src/ForceDotCom/UserTerritoryDeleteHeader.php
+++ b/src/ForceDotCom/UserTerritoryDeleteHeader.php
@@ -1,0 +1,39 @@
+<?php namespace CEE\Salesforce\ForceDotCom;
+
+/*
+ * Copyright (c) 2007, salesforce.com, inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided
+ * that the following conditions are met:
+ *
+ *    Redistributions of source code must retain the above copyright notice, this list of conditions and the
+ *    following disclaimer.
+ *
+ *    Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *    the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ *    Neither the name of salesforce.com, inc. nor the names of its contributors may be used to endorse or
+ *    promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+class UserTerritoryDeleteHeader
+{
+    public $transferToUserId;
+
+    public function __construct($transferToUserId)
+    {
+        $this->transferToUserId = $transferToUserId;
+    }
+}
+
+?>

--- a/src/Laravel/Facades/Salesforce.php
+++ b/src/Laravel/Facades/Salesforce.php
@@ -1,0 +1,37 @@
+<?php namespace CEE\Salesforce\Laravel\Facades;
+
+use CEE\Salesforce\ForceDotCom\Results\BasicResult;
+use CEE\Salesforce\ForceDotCom\Results\QueryResult;
+use CEE\Salesforce\ForceDotCom\SforceBaseClient;
+use CEE\Salesforce\ForceDotCom\SforceEnterpriseClient;
+use Illuminate\Support\Facades\Facade;
+
+/**
+ * Class SalesforceFacade
+ *
+ * @package  CEE\Salesforce\Laravel
+ *
+ * Facade for the Salesforce service
+ * @see SforceEnterpriseClient
+ *
+ * @method static QueryResult query(string $query)
+ * @see SforceBaseClient::query()
+ * @method static BasicResult create(array $sObjects, string $type)
+ * @see SforceEnterpriseClient::create()
+ * @method static BasicResult update(array $sObjects, string $type)
+ * @see SforceEnterpriseClient::update()
+ * @method static BasicResult delete(array $ids)
+ * @see SforceBaseClient::delete()
+ */
+class Salesforce extends Facade
+{
+    /**
+     * Get the registered name of the component.
+     *
+     * @return string
+     */
+    protected static function getFacadeAccessor()
+    {
+        return 'salesforce';
+    }
+}

--- a/src/Laravel/LICENSE.md
+++ b/src/Laravel/LICENSE.md
@@ -1,0 +1,22 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 Davis Peixoto
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/src/Laravel/SalesforceException.php
+++ b/src/Laravel/SalesforceException.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: dpeixoto
+ * Date: 8/11/16
+ * Time: 6:23 PM
+ */
+
+namespace CEE\Salesforce\Laravel;
+
+use Exception;
+
+class SalesforceException extends Exception
+{
+
+}

--- a/src/Laravel/SalesforceService.php
+++ b/src/Laravel/SalesforceService.php
@@ -1,0 +1,71 @@
+<?php namespace CEE\Salesforce\Laravel;
+
+use CEE\Salesforce\ForceDotCom\SforceEnterpriseClient as Client;
+use Exception;
+
+/**
+ * Class Salesforce
+ * @package CEE\Salesforce\Laravel
+ *
+ * The Salesforce service accessor Constructor
+ */
+class SalesforceService
+{
+    /**
+     * @var Client
+     */
+    public $sfh;
+
+    /**
+     * Salesforce constructor.
+     * @param Client $sfh
+     */
+    public function __construct(Client $sfh)
+    {
+        $this->sfh = $sfh;
+    }
+
+    /**
+     * @param $method
+     * @param $args
+     * @return mixed
+     */
+    public function __call($method, $args)
+    {
+        return call_user_func_array([$this->sfh, $method], $args);
+    }
+
+    /**
+     * Connect user into salesforce
+     *
+     * @param $configExternal
+     * @throws SalesforceException
+     */
+    public function connect($configExternal)
+    {
+        $wsdl = $configExternal->get('salesforce.wsdl');
+
+        if (empty($wsdl)) {
+            $wsdl = __DIR__ . '/Wsdl/enterprise.wsdl.xml';
+        }
+
+        $user = $configExternal->get('salesforce.username');
+        $pass = $configExternal->get('salesforce.password');
+        $token = $configExternal->get('salesforce.token');
+
+        try {
+            $this->sfh->createConnection($wsdl);
+            $this->sfh->login($user, $pass . $token);
+        } catch (Exception $e) {
+            throw new SalesforceException('Exception at Constructor' . $e->getMessage() . "\n\n" . $e->getTraceAsString());
+        }
+    }
+
+    /**
+     * @return mixed
+     */
+    public function dump()
+    {
+        return print_r($this, true);
+    }
+}

--- a/src/Laravel/SalesforceServiceProvider.php
+++ b/src/Laravel/SalesforceServiceProvider.php
@@ -1,0 +1,54 @@
+<?php namespace CEE\Salesforce\Laravel;
+
+use Illuminate\Support\ServiceProvider;
+use CEE\Salesforce\ForceDotCom\SforceEnterpriseClient as Client;
+
+/**
+ * Class SalesforceServiceProvider
+ * @package CEE\Salesforce\Laravel
+ *
+ * The Laravel Service Provider for Salesforce Service
+ */
+class SalesforceServiceProvider extends ServiceProvider
+{
+    /**
+     * Indicates if loading of the provider is deferred.
+     *
+     * @var bool
+     */
+    protected $defer = true;
+
+    /**
+     * @var
+     */
+    protected $sfh;
+
+    /**
+     * Register the service provider.
+     *
+     * @return void
+     */
+    public function register()
+    {
+        $config = __DIR__ . '/config/config.php';
+        $this->mergeConfigFrom($config, 'salesforce');
+        $this->publishes([$config => config_path('salesforce.php')]);
+
+        $this->app->singleton('salesforce', function ($app) {
+            $sf = new SalesforceService(new Client());
+            $sf->connect($app['config']);
+
+            return $sf;
+        });
+    }
+
+    /**
+     * Get the services provided by the provider.
+     *
+     * @return array
+     */
+    public function provides()
+    {
+        return ['salesforce', 'CEE\Salesforce\Laravel\SalesforceService'];
+    }
+}

--- a/src/Laravel/config/config.php
+++ b/src/Laravel/config/config.php
@@ -1,0 +1,17 @@
+<?php
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Your Salesforce credentials
+    |--------------------------------------------------------------------------
+    |
+    |
+    */
+
+    // production
+    'username' => env('SALESFORCE_USERNAME'),
+    'password' => env('SALESFORCE_PASSWORD'),
+    'token' => env('SALESFORCE_TOKEN'),
+    'wsdl' => storage_path('app/' . env('SALESFORCE_WSDL', 'wsdl/enterprise.wsdl.xml'))
+];

--- a/src/SyncObject.php
+++ b/src/SyncObject.php
@@ -24,7 +24,8 @@
 
 namespace CEE\Salesforce;
 
-use Salesforce;
+use CEE\Salesforce\ForceDotCom\Results\BasicResult;
+use CEE\Salesforce\Laravel\Facades\Salesforce;
 
 class SyncObject
 {
@@ -386,7 +387,7 @@ class SyncObject
 	/**
 	 * Check if a Salesforce SaveResult has all successful responses
 	 *
-	 * @param array|\stdClass $result
+	 * @param array|\stdClass|BasicResult $result
 	 * @return bool
 	 */
 	public static function isSuccessfulResult($result) {
@@ -405,9 +406,9 @@ class SyncObject
 	/**
 	 * Throw an exception if a Salesforce SaveResult is not successful
 	 *
-	 * @param array|\stdClass $result
-	 * @param SyncObject $syncObject
-	 * @param array $objects
+	 * @param array|\stdClass|BasicResult $result
+	 * @param SyncObject|null $syncObject
+	 * @param array|null $objects
 	 * @return array
 	 * @throws SalesforceSyncException
 	 */
@@ -424,10 +425,10 @@ class SyncObject
 	 * @param string $objectName
 	 * @param array $objects
 	 * @param int $retryLimit
-	 * @return mixed
+	 * @return array|BasicResult|\stdClass
 	 * @throws SalesforceSyncException
 	 */
-	public static function attemptSync($action, $objectName, $objects, $retryLimit=10) {
+	public static function attemptSync( string $action, string $objectName, array $objects, int $retryLimit=10) {
 		return SyncObject::objectName($objectName)->retry($retryLimit)->attemptSalesforceSync($action, $objects);
 	}
 
@@ -437,10 +438,10 @@ class SyncObject
 	 * @param string $action
 	 * @param array $objects
 	 * @param array $attempts
-	 * @return mixed
+	 * @return array|BasicResult|\stdClass
 	 * @throws SalesforceSyncException
 	 */
-	public function attemptSalesforceSync($action, $objects, $attempts=[]) {
+	public function attemptSalesforceSync( string $action, array $objects, array $attempts=[]) {
 		try {
 			$result = Salesforce::$action($objects, $this->objectName);
 		} catch(\SoapFault $exception) {
@@ -469,7 +470,7 @@ class SyncObject
 	/**
 	 * Check to see if a Salesforce SaveResult has a specific error code or codes
 	 *
-	 * @param array|\stdClass $result
+	 * @param array|\stdClass|BasicResult $result
 	 * @param string|array $code
 	 * @return bool
 	 */


### PR DESCRIPTION
Upgrade code base to work with Laravel versions 9, 10, and 11. Pulling in code from ForceDotCom and Davis Peixoto's Laravel5Salesforce packages to be able to update the code to work with higher version.